### PR TITLE
only enable crashlytics for release builds with real versioning

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/util/Properties.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/util/Properties.kt
@@ -3,9 +3,6 @@ package com.freeletics.gradle.util
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 
-val Project.isCiServer: Boolean
-    get() = providers.environmentVariable("CI").getOrElse("").toBoolean()
-
 @Suppress("UnstableApiUsage")
 fun Project.stringProperties(prefix: String): Provider<MutableMap<String, String>> {
     return providers.gradlePropertiesPrefixedBy(prefix)

--- a/monorepo/README.md
+++ b/monorepo/README.md
@@ -169,7 +169,8 @@ in the app.
 
 Applies the Crashlytics Gradle plugin and configures it for the release build type. This configuration
 does not require the Google services Gradle plugin but it expects `src/debug/res/values/google-services.xml`
-and `src/release/res/values/google-services.xml` to exist.
+and `src/release/res/values/google-services.xml` to exist. The Crashlytics mapping upload will only be enabled
+when `-Pfgp.computeInfoFromGit=true` is passed to the build.
 
 ```groovy
 freeletics {
@@ -177,7 +178,8 @@ freeletics {
 }
 ```
 
-There will also be a generated `BuildConfig.CRASHLYTICS_ENABLED` boolean field that is only `true` for CI builds.
+There will also be a generated `BuildConfig.CRASHLYTICS_ENABLED` boolean field that will only be `true` if the mapping 
+upload was enabled.
 
 
 ## `core` (Android)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/setup/CrashlyticsSetup.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/setup/CrashlyticsSetup.kt
@@ -4,7 +4,7 @@ import com.freeletics.gradle.monorepoplugins.VERSION
 import com.freeletics.gradle.tasks.ProcessGoogleResourcesTask.Companion.registerProcessGoogleResourcesTask
 import com.freeletics.gradle.util.androidApp
 import com.freeletics.gradle.util.androidComponentsApp
-import com.freeletics.gradle.util.isCiServer
+import com.freeletics.gradle.util.computeInfoFromGit
 import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
@@ -23,7 +23,12 @@ internal fun Project.configureCrashlytics() {
             }
 
             named("release") { releaseType ->
-                releaseType.buildConfigField("boolean", "CRASHLYTICS_ENABLED", "$isCiServer")
+                val enabled = computeInfoFromGit.get()
+                releaseType.buildConfigField("boolean", "CRASHLYTICS_ENABLED", "$enabled")
+                (releaseType as ExtensionAware).extensions.configure(CrashlyticsExtension::class.java) {
+                    it.mappingFileUploadEnabled = enabled
+                    it.nativeSymbolUploadEnabled = enabled
+                }
             }
         }
     }

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/Environment.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/Environment.kt
@@ -5,6 +5,11 @@ import org.gradle.api.Project
 
 private const val INJECT_BUILD_PROPERTIES_PROPERTY = "fgp.computeInfoFromGit"
 
+/**
+ * This property is used to determine whether real version information should be used for the app
+ * and whether Crashlytics should be enabled. If this is false or not set dummy values will be used
+ * for versioning and Crashlytics so that builds stay reproducible.
+ */
 internal val Project.computeInfoFromGit
     get() = booleanProperty(INJECT_BUILD_PROPERTIES_PROPERTY, false)
 


### PR DESCRIPTION
We had 2 issues with Crashlytics in `release` builds:
1. `CRASHLYTICS_ENABLED` differed between local and remote causing cache misses in the app module
2. Since the mapping file upload was always enabled Crashlytics would also always generate a new id on each build which again causes cache misses and also means that repeat local builds are not up to date

While this is just release builds which are not done that often it's still not great. 

I've tied both to the `computeInfoFromGit` flag that we use for release builds that are actually being published. These are the builds where Crashlytics actually matters and also usually one of builds so the build impact doesn't matter as much.