### PR TITLE
add common plugin for app modules

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidBasePlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.plugin
 
+import com.android.build.api.dsl.ApplicationDefaultConfig
 import com.android.build.api.variant.HasAndroidTestBuilder
 import com.freeletics.gradle.setup.configure
 import com.freeletics.gradle.setup.defaultTestSetup
@@ -45,6 +46,9 @@ abstract class FreeleticsAndroidBasePlugin : Plugin<Project> {
 
             compileSdk = getVersion("android.compile").toInt()
             defaultConfig.minSdk = getVersion("android.min").toInt()
+            (defaultConfig as? ApplicationDefaultConfig)?.let {
+                it.targetSdk = getVersion("android.target").toInt()
+            }
 
             // default all features to false, they will be enabled through FreeleticsAndroidExtension
             buildFeatures {

--- a/common/README.md
+++ b/common/README.md
@@ -121,7 +121,7 @@ android-min = "26"
 # the Android targetSdkVersion to use, only for app modules
 android-target = "33"
 # the Android compileSdkVersion to use
-android-compile=33
+android-compile = "33"
 
 [libraries]
 # if this is present coreLibraryDesugaring will be enabled and this dependency is automatically added 

--- a/common/README.md
+++ b/common/README.md
@@ -65,7 +65,7 @@ fl-whetstone-compiler = { module = "com.freeletics.mad:whetstone-compiler", vers
 ```
 
 
-## Android Library projects
+## Android projects
 
 Applies:
 - `com.android.library`
@@ -91,7 +91,10 @@ General features:
 
 ```groovy
 plugins {
+    // for library projects
     id("com.freeletics.gradle.common.android").version("<latest-version>")
+    // for app projects
+    id("com.freeletics.gradle.common.android.app").version("<latest-version>")
 }
 ```
 
@@ -114,9 +117,11 @@ java-toolchain=17
 kotlin-language=1.9
 
 # the Android minSdkVersion to use
-android.min=26
+android-min=26
+# the Android targetSdkVersion to use, only for app modules
+android-target=33
 # the Android compileSdkVersion to use
-android.compile=34
+android-compile=33
 
 [libraries]
 # if this is present coreLibraryDesugaring will be enabled and this dependency is automatically added 

--- a/common/README.md
+++ b/common/README.md
@@ -117,9 +117,9 @@ java-toolchain=17
 kotlin-language=1.9
 
 # the Android minSdkVersion to use
-android-min=26
+android-min = "26"
 # the Android targetSdkVersion to use, only for app modules
-android-target=33
+android-target = "33"
 # the Android compileSdkVersion to use
 android-compile=33
 

--- a/common/common.gradle
+++ b/common/common.gradle
@@ -20,6 +20,11 @@ gradlePlugin {
             implementationClass = "com.freeletics.gradle.plugin.FreeleticsAndroidPlugin"
         }
 
+        commonAndroidAppPlugin {
+            id = "com.freeletics.gradle.common.android.app"
+            implementationClass = "com.freeletics.gradle.plugin.FreeleticsAndroidAppPlugin"
+        }
+
         commonJvmPlugin {
             id = "com.freeletics.gradle.common.jvm"
             implementationClass = "com.freeletics.gradle.plugin.FreeleticsJvmPlugin"

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
@@ -1,0 +1,16 @@
+package com.freeletics.gradle.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+abstract class FreeleticsAndroidAppPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        target.plugins.apply("com.android.application")
+        target.plugins.apply("org.jetbrains.kotlin.android")
+        target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
+        target.plugins.apply("com.autonomousapps.dependency-analysis")
+
+        target.extensions.create("freeletics", FreeleticsAndroidExtension::class.java)
+    }
+}

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppPlugin.kt
@@ -29,8 +29,6 @@ abstract class AppPlugin : Plugin<Project> {
 
         @Suppress("UnstableApiUsage")
         target.androidApp {
-            defaultConfig.targetSdk = target.getVersion("android.target").toInt()
-
             signingConfigs {
                 named("debug") {
                     val debugKeystore = target.rootProject.file("gradle/debug.keystore")


### PR DESCRIPTION
Adds a plugin for simple app modules. This is basically a copy of the existing `FreeleticsAndroidPlugin` that simply applies `com.android.application` instead of `com.android.library`. I've also moved the setting of the target sdk to the base Android config so that it works here as well.