### PR TITLE
add option whether native symbols upload is enabled

### DIFF
--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppExtension.kt
@@ -59,8 +59,9 @@ abstract class AppExtension(project: Project) : FreeleticsAndroidExtension(proje
         project.configureLicensee()
     }
 
-    fun crashReporting() {
-        project.configureCrashlytics()
+    @JvmOverloads
+    fun crashReporting(uploadNativeSymbols: Boolean = false) {
+        project.configureCrashlytics(uploadNativeSymbols)
     }
 
     fun versionFromGit(gitTagName: String) {

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/setup/CrashlyticsSetup.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/setup/CrashlyticsSetup.kt
@@ -9,7 +9,7 @@ import com.google.firebase.crashlytics.buildtools.gradle.CrashlyticsExtension
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 
-internal fun Project.configureCrashlytics() {
+internal fun Project.configureCrashlytics(uploadNativeSymbols: Boolean) {
     plugins.apply("com.google.firebase.crashlytics")
 
     androidApp {
@@ -27,7 +27,7 @@ internal fun Project.configureCrashlytics() {
                 releaseType.buildConfigField("boolean", "CRASHLYTICS_ENABLED", "$enabled")
                 (releaseType as ExtensionAware).extensions.configure(CrashlyticsExtension::class.java) {
                     it.mappingFileUploadEnabled = enabled
-                    it.nativeSymbolUploadEnabled = enabled
+                    it.nativeSymbolUploadEnabled = enabled && uploadNativeSymbols
                 }
             }
         }


### PR DESCRIPTION
Crashlytics will fail if this is set to true but there aren't any native symbols.