### PR TITLE
add dokka automatically with oss publish, disable for snapshots

### DIFF
--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.api.Project
 abstract class FreeleticsPublishOssPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
+        target.plugins.apply("org.jetbrains.dokka")
         target.plugins.apply("com.vanniktech.maven.publish")
 
         target.extensions.configure(MavenPublishBaseExtension::class.java) {
@@ -17,5 +18,20 @@ abstract class FreeleticsPublishOssPlugin : Plugin<Project> {
         }
 
         target.configurePom(includeLicense = true)
+
+        // if the version is a snapshot version disable dokka tasks to speed up the build
+        if (target.findProperty("VERSION_NAME")?.toString()?.endsWith("-SNAPSHOT") == true) {
+            target.afterEvaluate {
+                target.tasks.named("dokkaHtml").configure { task ->
+                    task.enabled = false
+                }
+
+                it.plugins.withId("com.android.library") {
+                    target.tasks.named("javaDocReleaseGeneration").configure { task ->
+                        task.enabled = false
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
We always add dokka to the published projects so we can just let the oss plugin take care of applying it. I'd do the same for the binary compatibility plugin but it currently expects to be applied to the root project and does an `allprojects` to apply it to all others as well, so we can't do that for now. 

To speed up snapshot publishing I disabled the dokka tasks when the current version is a snapshot so that snapshot publishing gets a lot faster in projects with lots of modules. Most time there is spent on dokka generation.