### PR TITLE
filter default repositories and snapshot repositories

### DIFF
--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
@@ -9,15 +9,31 @@ abstract class SettingsExtension(private val settings: Settings) {
             management.repositories { handler ->
                 handler.maven {
                     it.setUrl("https://oss.sonatype.org/content/repositories/snapshots/")
+                    it.mavenContent { content ->
+                        content.snapshotsOnly()
+                    }
                 }
                 handler.maven {
                     it.setUrl("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+                    it.mavenContent { content ->
+                        content.snapshotsOnly()
+                    }
                 }
                 handler.maven {
                     it.setUrl("https://androidx.dev/storage/compose-compiler/repository/")
+
+                    it.mavenContent { content ->
+                        // limit to androidx.compose.compiler dev versions
+                        content.includeVersionByRegex("^androidx.compose.compiler\$", ".*", ".+-dev-k.+")
+                    }
                 }
                 handler.maven {
                     it.setUrl("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap")
+                    it.mavenContent { content ->
+                        // limit to org.jetbrains.kotlin artifacts with -dev- or -release-
+                        content.includeVersionByRegex("^org.jetbrains.kotlin.*", ".*", ".*-(dev|release)-.*")
+
+                    }
                 }
                 handler.mavenLocal()
             }

--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
@@ -21,7 +21,6 @@ abstract class SettingsExtension(private val settings: Settings) {
                 }
                 handler.maven {
                     it.setUrl("https://androidx.dev/storage/compose-compiler/repository/")
-
                     it.mavenContent { content ->
                         // limit to androidx.compose.compiler dev versions
                         content.includeVersionByRegex("^androidx.compose.compiler\$", ".*", ".+-dev-k.+")

--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
@@ -52,7 +52,7 @@ abstract class SettingsPlugin : Plugin<Settings> {
                         }
 
                         content.filter {
-                            it.includeGroupByRegex("com\\.freeletics\\.internal.*")
+                            it.includeGroupByRegex("^com\\.freeletics\\.internal.*")
                             // manually uploaded because only published on jitpack
                             it.includeModule("com.github.kamikat.moshi-jsonapi", "core")
                             it.includeModule("com.github.kamikat.moshi-jsonapi", "retrofit-converter")
@@ -64,16 +64,18 @@ abstract class SettingsPlugin : Plugin<Settings> {
                     content.forRepository { handler.google() }
 
                     content.filter {
-                        it.includeGroupByRegex("com\\.android.*")
-                        it.includeGroupByRegex("androidx\\..*")
-                        it.includeGroupByRegex("android\\..*")
+                        it.includeGroupByRegex("^com\\.android.*")
+                        it.includeGroupByRegex("^android\\..*")
+                        // all of AndroidX except for androidx.compose.compiler and -SNAPSHOT versions
+                        it.includeVersionByRegex("^androidx\\..*(?<!compose\\.compiler)\$", ".*", ".*(?<!-SNAPSHOT)\$")
+                        // androidx.compose.compiler but not dev versions because they come from a different repository
+                        it.includeVersionByRegex("^androidx.compose.compiler\$", ".*", "^((?!-dev-k).)*\$")
 
                         it.includeGroup("com.google.android.exoplayer")
                         it.includeGroup("com.google.android.material")
                         it.includeGroup("com.google.android.gms")
                         it.includeGroup("com.google.android.play")
                         it.includeGroup("com.google.android.datatransport")
-                        it.includeGroup("com.google.android.flexbox")
                         it.includeGroup("com.google.firebase")
                         it.includeGroup("com.google.testing.platform")
                         it.includeGroup("com.google.android.apps.common.testing.accessibility.framework")
@@ -84,12 +86,16 @@ abstract class SettingsPlugin : Plugin<Settings> {
                     content.forRepository { handler.gradlePluginPortal() }
 
                     content.filter {
-                        it.includeGroupByRegex("com.gradle.*")
-                        it.includeGroupByRegex("org.gradle.*")
+                        it.includeGroupByRegex("^com.gradle.*")
+                        it.includeGroupByRegex("^org.gradle.*")
                     }
                 }
 
-                handler.mavenCentral()
+                handler.mavenCentral {
+                    it.mavenContent { content ->
+                        content.releasesOnly()
+                    }
+                }
             }
 
             // TODO https://youtrack.jetbrains.com/issue/KT-51379


### PR DESCRIPTION
- limit maven central to non snapshot versions
- limit Sonatype snapshot repositories to snapshot versions
- limit compiler compiler dev repository to dev versions of the compiler
- limit jetbrains bootstrap repo to org.jetbrains.kotlin and dev/release versions
- adjust regex for AndroidX in Google Maven to not include [snapshots](https://androidx.dev/) (we don't add these repos automatically as part of `snapshots` because of the changing number in the url) and to not include [dev versions of the compose compiler](https://androidx.dev/storage/compose-compiler/repository)

The first 4 points are just small improvements for when snapshots are enabled. The last one is needed to make compose compiler dev versions and AndroidX snapshots work at all. Because we are using `exclusiveContent` for Google Maven before this any AndroidX artifact could only come from there.