### PR TITLE
automatically enable explicitApi from the OSS plugin

### DIFF
--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
@@ -12,6 +12,9 @@ abstract class FreeleticsPublishOssPlugin : Plugin<Project> {
         target.plugins.apply("org.jetbrains.dokka")
         target.plugins.apply("com.vanniktech.maven.publish")
 
+        val extension = target.extensions.findByName("freeletics") as FreeleticsBaseExtension
+        extension.explicitApi()
+        
         target.extensions.configure(MavenPublishBaseExtension::class.java) {
             it.publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)
             it.signAllPublications()


### PR DESCRIPTION
We do this manually in each project right now and I don't really see a downside of enabling this generally for open source libraries. Even if we would have a few modules which are not necessarily libraries like a gradle plugin.