### PR TITLE
fix generatePluginVersion task dependencies and configuration cache

### DIFF
--- a/common/src/main/kotlin/com/freeletics/gradle/tasks/GenerateVersionClass.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/tasks/GenerateVersionClass.kt
@@ -1,13 +1,13 @@
 package com.freeletics.gradle.tasks
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
-abstract class GenerateVersion : DefaultTask() {
+abstract class GenerateVersionClass : DefaultTask() {
 
     @get:Input
     abstract val packageName: Property<String>
@@ -15,17 +15,18 @@ abstract class GenerateVersion : DefaultTask() {
     @get:Input
     abstract val version: Property<String>
 
-    @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+    @get:OutputDirectory
+    abstract val outputDirectory: DirectoryProperty
 
     @TaskAction
     fun generate() {
-        outputFile.get().asFile.writeText(
+        val file = outputDirectory.file("${packageName.get().replace(".", "/")}/Version.kt").get().asFile
+        file.writeText(
             """
             // Generated file. Do not edit!
             package ${packageName.get()}
             
-            const val VERSION = "${version.get()}"
+            internal const val VERSION = "${version.get()}"
             """.trimIndent()
         )
     }


### PR DESCRIPTION
- Removes the manual task dependencies. Instead of adding the output directory to the main source set it passes our task. This will then automatically make tasks that consume the sources depend on our task.
- The task wasn't configuration cache compatible (see comment on pr).
- Because of the explicit api mode addition in #24 I've changed the generated `VERSION` constant to `internal`.