### PR TITLE
enable STABLE_CONFIGURATION_CACHE feature preview

### DIFF
--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
@@ -37,6 +37,10 @@ abstract class SettingsPlugin : Plugin<Settings> {
 
         target.enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+        if (target.providers.gradleProperty("fgp.stableConfigurationCache").getOrElse("true").toBoolean()) {
+            target.enableFeaturePreview("STABLE_CONFIGURATION_CACHE")
+        }
+
         target.dependencyResolutionManagement { management ->
             @Suppress("UnstableApiUsage")
             management.repositories { handler ->


### PR DESCRIPTION
Adds some more strictness for configuration cache, see https://docs.gradle.org/current/userguide/configuration_cache.html. I've added an opt out Gradle property so that we can easily disable if something is not compatible without being blocked.