### PR TITLE
add visibility modifiers

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidBasePlugin.kt
@@ -19,7 +19,7 @@ import org.gradle.api.tasks.testing.Test
 import org.slf4j.ILoggerFactory
 import org.slf4j.LoggerFactory
 
-abstract class FreeleticsAndroidBasePlugin : Plugin<Project> {
+public abstract class FreeleticsAndroidBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsBasePlugin::class.java)

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -13,7 +13,7 @@ import com.freeletics.gradle.util.kotlin
 import com.freeletics.gradle.util.stringProperty
 import org.gradle.api.Project
 
-abstract class FreeleticsAndroidExtension(project: Project) : FreeleticsBaseExtension(project) {
+public abstract class FreeleticsAndroidExtension(project: Project) : FreeleticsBaseExtension(project) {
 
     fun useRoom() {
         val processorConfiguration = project.configureProcessing()

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -6,7 +6,7 @@ import com.freeletics.gradle.util.compilerOptions
 import com.freeletics.gradle.util.kotlin
 import org.gradle.api.Project
 
-abstract class FreeleticsBaseExtension(protected val project: Project) {
+public abstract class FreeleticsBaseExtension(protected val project: Project) {
 
     fun explicitApi() {
         project.kotlin {

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -13,7 +13,7 @@ import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JvmVendorSpec
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
-abstract class FreeleticsBasePlugin : Plugin<Project> {
+public abstract class FreeleticsBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.makeJarsReproducible()

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmBasePlugin.kt
@@ -8,7 +8,7 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.testing.Test
 
-abstract class FreeleticsJvmBasePlugin : Plugin<Project> {
+public abstract class FreeleticsJvmBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsBasePlugin::class.java)

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmExtension.kt
@@ -3,7 +3,7 @@ package com.freeletics.gradle.plugin
 import com.freeletics.gradle.setup.configureStandaloneLint
 import org.gradle.api.Project
 
-abstract class FreeleticsJvmExtension(project: Project) : FreeleticsBaseExtension(project) {
+public abstract class FreeleticsJvmExtension(project: Project) : FreeleticsBaseExtension(project) {
 
     fun useAndroidLint() {
         project.plugins.apply("com.android.lint")

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/ProcessingSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/ProcessingSetup.kt
@@ -7,7 +7,7 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.internal.KaptGenerateStubsTask
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 
-fun Project.configureProcessing(vararg arguments: Pair<String, String>): String {
+public fun Project.configureProcessing(vararg arguments: Pair<String, String>): String {
     val useKsp = booleanProperty("fgp.kotlin.ksp", true)
     if (useKsp.get()) {
         plugins.apply("com.google.devtools.ksp")

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/TestTaskSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/TestTaskSetup.kt
@@ -2,7 +2,7 @@ package com.freeletics.gradle.setup
 
 import org.gradle.api.tasks.testing.Test
 
-fun Test.defaultTestSetup() {
+public fun Test.defaultTestSetup() {
     val projectName = project.path
         .replace("projects", "")
         .replaceFirst(":", "")

--- a/base/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
@@ -13,26 +13,26 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-fun Project.java(action: JavaPluginExtension.() -> Unit) {
+public fun Project.java(action: JavaPluginExtension.() -> Unit) {
     extensions.configure(JavaPluginExtension::class.java) {
         it.action()
     }
 }
 
-fun Project.kotlin(action: KotlinProjectExtension.() -> Unit) {
+public fun Project.kotlin(action: KotlinProjectExtension.() -> Unit) {
     extensions.configure(KotlinProjectExtension::class.java) {
         it.action()
     }
 }
 
-fun Project.kotlinMultiplatform(action: KotlinMultiplatformExtension.() -> Unit) {
+public fun Project.kotlinMultiplatform(action: KotlinMultiplatformExtension.() -> Unit) {
     extensions.configure(KotlinMultiplatformExtension::class.java) {
         it.action()
     }
 }
 
 @Suppress("UnusedReceiverParameter") // until KGP provides something like this
-fun KotlinProjectExtension.compilerOptions(project: Project, action: KotlinJvmCompilerOptions.() -> Unit) {
+public fun KotlinProjectExtension.compilerOptions(project: Project, action: KotlinJvmCompilerOptions.() -> Unit) {
     project.tasks.withType(KotlinCompile::class.java).configureEach {
         it.compilerOptions {
             action()
@@ -40,37 +40,37 @@ fun KotlinProjectExtension.compilerOptions(project: Project, action: KotlinJvmCo
     }
 }
 
-fun Project.android(action: CommonExtension<*, *, *, *>.() -> Unit) {
+public fun Project.android(action: CommonExtension<*, *, *, *>.() -> Unit) {
     extensions.configure(CommonExtension::class.java) {
         it.action()
     }
 }
 
-fun Project.androidLibrary(action: LibraryExtension.() -> Unit) {
+public fun Project.androidLibrary(action: LibraryExtension.() -> Unit) {
     extensions.configure(LibraryExtension::class.java) {
         it.action()
     }
 }
 
-fun Project.androidApp(action: ApplicationExtension.() -> Unit) {
+public fun Project.androidApp(action: ApplicationExtension.() -> Unit) {
     extensions.configure(ApplicationExtension::class.java) {
         it.action()
     }
 }
 
-fun Project.androidComponents(action: AndroidComponentsExtension<*, *, *>.() -> Unit) {
+public fun Project.androidComponents(action: AndroidComponentsExtension<*, *, *>.() -> Unit) {
     extensions.configure(AndroidComponentsExtension::class.java) {
         it.action()
     }
 }
 
-fun Project.androidComponentsLibrary(action: LibraryAndroidComponentsExtension.() -> Unit) {
+public fun Project.androidComponentsLibrary(action: LibraryAndroidComponentsExtension.() -> Unit) {
     extensions.configure(LibraryAndroidComponentsExtension::class.java) {
         it.action()
     }
 }
 
-fun Project.androidComponentsApp(action: ApplicationAndroidComponentsExtension.() -> Unit) {
+public fun Project.androidComponentsApp(action: ApplicationAndroidComponentsExtension.() -> Unit) {
     extensions.configure(ApplicationAndroidComponentsExtension::class.java) {
         it.action()
     }

--- a/base/src/main/kotlin/com/freeletics/gradle/util/Properties.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/util/Properties.kt
@@ -4,12 +4,12 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 
 @Suppress("UnstableApiUsage")
-fun Project.stringProperties(prefix: String): Provider<MutableMap<String, String>> {
+public fun Project.stringProperties(prefix: String): Provider<MutableMap<String, String>> {
     return providers.gradlePropertiesPrefixedBy(prefix)
 }
 
-fun Project.stringProperty(name: String): Provider<String> = providers.gradleProperty(name)
+public fun Project.stringProperty(name: String): Provider<String> = providers.gradleProperty(name)
 
-fun Project.booleanProperty(name: String, defaultValue: Boolean): Provider<Boolean> {
+public fun Project.booleanProperty(name: String, defaultValue: Boolean): Provider<Boolean> {
     return stringProperty(name).map { it.toBoolean() }.orElse(defaultValue)
 }

--- a/base/src/main/kotlin/com/freeletics/gradle/util/VersionCatalog.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/util/VersionCatalog.kt
@@ -12,27 +12,27 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 private val Project.libs: VersionCatalog
     get() = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
 
-fun Project.getDependency(name: String): Provider<MinimalExternalModuleDependency> {
+public fun Project.getDependency(name: String): Provider<MinimalExternalModuleDependency> {
     return libs.findLibrary(name).orElseThrow { NoSuchElementException("Could not find library $name") }
 }
 
-fun Project.getDependencyOrNull(name: String): Provider<MinimalExternalModuleDependency>? {
+public fun Project.getDependencyOrNull(name: String): Provider<MinimalExternalModuleDependency>? {
     return libs.findLibrary(name).orElseGet { null }
 }
 
-fun Project.getVersion(name: String): String {
+public fun Project.getVersion(name: String): String {
     return getVersionOrNull(name) ?: throw NoSuchElementException("Could not find version $name")
 }
 
-fun Project.getVersionOrNull(name: String): String? {
+public fun Project.getVersionOrNull(name: String): String? {
     return libs.findVersion(name).orElseGet { null }?.requiredVersion
 }
 
-val Project.javaTargetVersion: JavaVersion
+public val Project.javaTargetVersion: JavaVersion
     get() = JavaVersion.toVersion(getVersion("java-target"))
 
-val Project.jvmTarget
+public val Project.jvmTarget
     get() = JvmTarget.fromTarget(getVersion("java-target"))
 
-val Project.javaToolchainVersion
+public val Project.javaToolchainVersion
     get() = JavaLanguageVersion.of(getVersion("java-toolchain"))

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
@@ -3,7 +3,7 @@ package com.freeletics.gradle.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class FreeleticsAndroidAppPlugin : Plugin<Project> {
+public abstract class FreeleticsAndroidAppPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply("com.android.application")

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
@@ -3,7 +3,7 @@ package com.freeletics.gradle.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class FreeleticsAndroidPlugin : Plugin<Project> {
+public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply("com.android.library")

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsGradlePluginPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsGradlePluginPlugin.kt
@@ -8,7 +8,7 @@ import com.freeletics.gradle.util.stringProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class FreeleticsGradlePluginPlugin : Plugin<Project> {
+public abstract class FreeleticsGradlePluginPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply("java-gradle-plugin")

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
@@ -3,7 +3,7 @@ package com.freeletics.gradle.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class FreeleticsJvmPlugin : Plugin<Project> {
+public abstract class FreeleticsJvmPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply("org.jetbrains.kotlin.jvm")

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -8,17 +8,17 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFrameworkConfig
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
-abstract class FreeleticsMultiplatformExtension(project: Project) : FreeleticsBaseExtension(project) {
+public abstract class FreeleticsMultiplatformExtension(project: Project) : FreeleticsBaseExtension(project) {
 
     @JvmOverloads
-    fun addJvmTarget(configure: KotlinJvmTarget.() -> Unit = { }) {
+    public fun addJvmTarget(configure: KotlinJvmTarget.() -> Unit = { }) {
         project.kotlinMultiplatform {
             jvm(configure = configure)
         }
     }
 
     @JvmOverloads
-    fun addIosTargets(
+    public fun addIosTargets(
         frameworkName: String,
         createXcFramework: Boolean = false,
         configure: KotlinNativeTarget.() -> Unit = { },
@@ -74,7 +74,7 @@ abstract class FreeleticsMultiplatformExtension(project: Project) : FreeleticsBa
         }
     }
 
-    fun addCommonTargets() {
+    public fun addCommonTargets() {
         project.kotlinMultiplatform {
             jvm()
 

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
@@ -5,7 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
 
-abstract class FreeleticsMultiplatformPlugin : Plugin<Project> {
+public abstract class FreeleticsMultiplatformPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply("org.jetbrains.kotlin.multiplatform")

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishInternalPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishInternalPlugin.kt
@@ -8,7 +8,7 @@ import org.gradle.api.credentials.AwsCredentials
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 
-abstract class FreeleticsPublishInternalPlugin : Plugin<Project> {
+public abstract class FreeleticsPublishInternalPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply("com.vanniktech.maven.publish")

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
@@ -6,7 +6,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class FreeleticsPublishOssPlugin : Plugin<Project> {
+public abstract class FreeleticsPublishOssPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply("org.jetbrains.dokka")

--- a/common/src/main/kotlin/com/freeletics/gradle/setup/Gr8.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/setup/Gr8.kt
@@ -3,7 +3,7 @@ package com.freeletics.gradle.setup
 import com.gradleup.gr8.Gr8Extension
 import org.gradle.api.Project
 
-fun Project.setupGr8() {
+internal fun Project.setupGr8() {
     val shadeConfiguration = configurations.create("shade")
 
     configurations.named("compileOnly").configure {

--- a/common/src/main/kotlin/com/freeletics/gradle/tasks/GenerateVersionClass.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/tasks/GenerateVersionClass.kt
@@ -7,19 +7,19 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
-abstract class GenerateVersionClass : DefaultTask() {
+public abstract class GenerateVersionClass : DefaultTask() {
 
     @get:Input
-    abstract val packageName: Property<String>
+    public abstract val packageName: Property<String>
 
     @get:Input
-    abstract val version: Property<String>
+    public abstract val version: Property<String>
 
     @get:OutputDirectory
-    abstract val outputDirectory: DirectoryProperty
+    public abstract val outputDirectory: DirectoryProperty
 
     @TaskAction
-    fun generate() {
+    public fun generate() {
         val file = outputDirectory.file("${packageName.get().replace(".", "/")}/Version.kt").get().asFile
         file.writeText(
             """

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ truth = "1.1.3"
 gradle-api = { module = "dev.gradleplugins:gradle-api", version.ref = "gradle-api" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+coroutines = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.4"
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 
@@ -47,6 +48,10 @@ gradle-toolchain = { module = "org.gradle.toolchains:foojay-resolver", version.r
 
 gr8 = { module = "com.gradleup:gr8-plugin", version.ref = "gr8" }
 publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "publish"}
+
+clikt = "com.github.ajalt.clikt:clikt-jvm:3.5.2"
+ktlint = "com.pinterest.ktlint:ktlint-core:0.48.2"
+ktlint-rules = "com.pinterest.ktlint:ktlint-ruleset-standard:0.48.2"
 
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppExtension.kt
@@ -23,28 +23,28 @@ import com.freeletics.gradle.util.environmentBuildConfigFields
 import java.io.File
 import org.gradle.api.Project
 
-abstract class AppExtension(project: Project) : FreeleticsAndroidExtension(project) {
+public abstract class AppExtension(project: Project) : FreeleticsAndroidExtension(project) {
 
-    fun applicationId(applicationId: String) {
+    public fun applicationId(applicationId: String) {
         project.androidApp {
             defaultConfig.applicationId = applicationId
         }
     }
 
-    fun applicationIdSuffix(buildType: String, suffix: String) {
+    public fun applicationIdSuffix(buildType: String, suffix: String) {
         project.androidApp {
             buildTypes.getByName(buildType).applicationIdSuffix = suffix
         }
     }
 
-    fun limitLanguagesTo(vararg configs: String) {
+    public fun limitLanguagesTo(vararg configs: String) {
         project.androidApp {
             defaultConfig.resourceConfigurations += configs
         }
     }
 
     @Suppress("UnstableApiUsage")
-    fun minify(vararg files: File) {
+    public fun minify(vararg files: File) {
         project.androidApp {
             buildTypes.getByName("release") {
                 it.isMinifyEnabled = true
@@ -55,16 +55,16 @@ abstract class AppExtension(project: Project) : FreeleticsAndroidExtension(proje
         project.dependencies.add("api", "com.freeletics.gradle:minify-common:$VERSION")
     }
 
-    fun checkLicenses() {
+    public fun checkLicenses() {
         project.configureLicensee()
     }
 
     @JvmOverloads
-    fun crashReporting(uploadNativeSymbols: Boolean = false) {
+    public fun crashReporting(uploadNativeSymbols: Boolean = false) {
         project.configureCrashlytics(uploadNativeSymbols)
     }
 
-    fun versionFromGit(gitTagName: String) {
+    public fun versionFromGit(gitTagName: String) {
         val versionNameTask = project.registerComputeVersionNameTask(gitTagName)
         val versionCodeTask = project.registerComputeVersionCodeTask(gitTagName)
         val gitShaTask = project.registerComputeGitShaTask()
@@ -83,7 +83,7 @@ abstract class AppExtension(project: Project) : FreeleticsAndroidExtension(proje
         }
     }
 
-    fun freeleticsBackend() {
+    public fun freeleticsBackend() {
         environmentBuildConfig(
             environments = listOf(PRODUCTION, INTEGRATION, QA),
             defaultDebugEnvironment = INTEGRATION,
@@ -113,7 +113,7 @@ abstract class AppExtension(project: Project) : FreeleticsAndroidExtension(proje
      * For example `fpg.app.config.google.client_id.production` with `DEFAULT` as `environmentName` will result in
      * `DEFAULT_GOOGLE_CLIENT_ID`.
      */
-    fun environmentBuildConfig(
+    public fun environmentBuildConfig(
         environments: List<String>,
         defaultDebugEnvironment: String,
         defaultReleaseEnvironment: String,

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppPlugin.kt
@@ -13,7 +13,7 @@ import com.freeletics.gradle.util.stringProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class AppPlugin : Plugin<Project> {
+public abstract class AppPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("com.android.application")
         target.plugins.apply("org.jetbrains.kotlin.android")

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreAndroidPlugin.kt
@@ -8,7 +8,7 @@ import com.freeletics.gradle.util.ProjectType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class CoreAndroidPlugin : Plugin<Project> {
+public abstract class CoreAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("com.android.library")
         target.plugins.apply("org.jetbrains.kotlin.android")

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreKotlinPlugin.kt
@@ -7,7 +7,7 @@ import com.freeletics.gradle.util.ProjectType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class CoreKotlinPlugin : Plugin<Project> {
+public abstract class CoreKotlinPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidExtension.kt
@@ -2,7 +2,7 @@ package com.freeletics.gradle.plugin
 
 import org.gradle.api.Project
 
-abstract class DomainAndroidExtension(project: Project) : FreeleticsAndroidExtension(project) {
+public abstract class DomainAndroidExtension(project: Project) : FreeleticsAndroidExtension(project) {
 
-    var allowLegacyDependencies = false
+    public var allowLegacyDependencies: Boolean = false
 }

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidPlugin.kt
@@ -10,7 +10,7 @@ import com.freeletics.gradle.util.projectType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class DomainAndroidPlugin : Plugin<Project> {
+public abstract class DomainAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("com.android.library")
         target.plugins.apply("org.jetbrains.kotlin.android")

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinExtension.kt
@@ -2,7 +2,7 @@ package com.freeletics.gradle.plugin
 
 import org.gradle.api.Project
 
-abstract class DomainKotlinExtension(project: Project) : FreeleticsJvmExtension(project) {
+public abstract class DomainKotlinExtension(project: Project) : FreeleticsJvmExtension(project) {
 
-    var allowLegacyDependencies = false
+    public var allowLegacyDependencies: Boolean = false
 }

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinPlugin.kt
@@ -7,7 +7,7 @@ import com.freeletics.gradle.util.ProjectType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class DomainKotlinPlugin : Plugin<Project> {
+public abstract class DomainKotlinPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeatureExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeatureExtension.kt
@@ -2,7 +2,7 @@ package com.freeletics.gradle.plugin
 
 import org.gradle.api.Project
 
-abstract class FeatureExtension(project: Project) : FreeleticsAndroidExtension(project) {
+public abstract class FeatureExtension(project: Project) : FreeleticsAndroidExtension(project) {
 
-    var allowLegacyDependencies = false
+    public var allowLegacyDependencies: Boolean = false
 }

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeaturePlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeaturePlugin.kt
@@ -9,7 +9,7 @@ import com.freeletics.gradle.util.appType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class FeaturePlugin : Plugin<Project> {
+public abstract class FeaturePlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("com.android.library")
         target.plugins.apply("org.jetbrains.kotlin.android")

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyAndroidPlugin.kt
@@ -9,7 +9,7 @@ import com.freeletics.gradle.util.projectType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class LegacyAndroidPlugin : Plugin<Project> {
+public abstract class LegacyAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("com.android.library")
         target.plugins.apply("org.jetbrains.kotlin.android")

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyKotlinPlugin.kt
@@ -7,7 +7,7 @@ import com.freeletics.gradle.util.ProjectType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class LegacyKotlinPlugin : Plugin<Project> {
+public abstract class LegacyKotlinPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/NavPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/NavPlugin.kt
@@ -9,7 +9,7 @@ import com.freeletics.gradle.util.appType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-abstract class NavPlugin : Plugin<Project> {
+public abstract class NavPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("com.android.library")
         target.plugins.apply("org.jetbrains.kotlin.android")

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/CheckDependencyRulesTask.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/CheckDependencyRulesTask.kt
@@ -20,24 +20,24 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 
 @CacheableTask
-abstract class CheckDependencyRulesTask : DefaultTask() {
+public abstract class CheckDependencyRulesTask : DefaultTask() {
     @get:Input
-    abstract val projectPath: Property<String>
+    public abstract val projectPath: Property<String>
 
     @get:Input
-    abstract val allowedProjectTypes: ListProperty<ProjectType>
+    public abstract val allowedProjectTypes: ListProperty<ProjectType>
 
     @get:Input
-    abstract val allowedDependencyProjectTypes: ListProperty<ProjectType>
+    public abstract val allowedDependencyProjectTypes: ListProperty<ProjectType>
 
     @get:Input
-    abstract val artifactIds: Property<ResolvedComponentResult>
+    public abstract val artifactIds: Property<ResolvedComponentResult>
 
     @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+    public abstract val outputFile: RegularFileProperty
 
     @TaskAction
-    fun check() {
+    public fun check() {
         val projectPath = this.projectPath.get()
         val component = this.artifactIds.get()
         val errors = component.dependencies
@@ -79,7 +79,7 @@ abstract class CheckDependencyRulesTask : DefaultTask() {
         }
     }
 
-    companion object {
+    internal companion object {
         private val CATEGORY = Attribute.of("org.gradle.category", String::class.java)
 
         fun Project.registerCheckDependencyRulesTasks(

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeGitShaTask.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeGitShaTask.kt
@@ -14,19 +14,19 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 
-abstract class ComputeGitShaTask : DefaultTask() {
+public abstract class ComputeGitShaTask : DefaultTask() {
 
     @get:Input
-    abstract val computeFromGit: Property<Boolean>
+    public abstract val computeFromGit: Property<Boolean>
 
     @get:Input
-    abstract val gitRootDirectory: Property<File>
+    public abstract val gitRootDirectory: Property<File>
 
     @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+    public abstract val outputFile: RegularFileProperty
 
     @TaskAction
-    fun action() {
+    public fun action() {
         val gitSha = if (computeFromGit.get()) {
             val git = RealGit(gitRootDirectory.get())
             git.commitSha()

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeGitTimestampTask.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeGitTimestampTask.kt
@@ -14,19 +14,19 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 
-abstract class ComputeGitTimestampTask : DefaultTask() {
+public abstract class ComputeGitTimestampTask : DefaultTask() {
 
     @get:Input
-    abstract val computeFromGit: Property<Boolean>
+    public abstract val computeFromGit: Property<Boolean>
 
     @get:Input
-    abstract val gitRootDirectory: Property<File>
+    public abstract val gitRootDirectory: Property<File>
 
     @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+    public abstract val outputFile: RegularFileProperty
 
     @TaskAction
-    fun action() {
+    public fun action() {
         val timestamp = if (computeFromGit.get()) {
             val git = RealGit(gitRootDirectory.get())
             git.commitTimestamp()

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersionCodeTask.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersionCodeTask.kt
@@ -14,22 +14,22 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 
-abstract class ComputeVersionCodeTask : DefaultTask() {
+public abstract class ComputeVersionCodeTask : DefaultTask() {
 
     @get:Input
-    abstract val computeFromGit: Property<Boolean>
+    public abstract val computeFromGit: Property<Boolean>
 
     @get:Input
-    abstract val gitTagName: Property<String>
+    public abstract val gitTagName: Property<String>
 
     @get:Input
-    abstract val gitRootDirectory: Property<File>
+    public abstract val gitRootDirectory: Property<File>
 
     @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+    public abstract val outputFile: RegularFileProperty
 
     @TaskAction
-    fun action() {
+    public fun action() {
         val versionCode = if (computeFromGit.get()) {
             val git = RealGit(gitRootDirectory.get())
             computeVersionCode(git, gitTagName.get(), LocalDate.now())

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersionNameTask.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersionNameTask.kt
@@ -13,22 +13,22 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 
-abstract class ComputeVersionNameTask : DefaultTask() {
+public abstract class ComputeVersionNameTask : DefaultTask() {
 
     @get:Input
-    abstract val computeFromGit: Property<Boolean>
+    public abstract val computeFromGit: Property<Boolean>
 
     @get:Input
-    abstract val gitTagName: Property<String>
+    public abstract val gitTagName: Property<String>
 
     @get:Input
-    abstract val gitRootDirectory: Property<File>
+    public abstract val gitRootDirectory: Property<File>
 
     @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+    public abstract val outputFile: RegularFileProperty
 
     @TaskAction
-    fun action() {
+    public fun action() {
         val versionName = if (computeFromGit.get()) {
             val git = RealGit(gitRootDirectory.get())
             computeVersionName(git, gitTagName.get())

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ProcessGoogleResourcesTask.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ProcessGoogleResourcesTask.kt
@@ -7,12 +7,12 @@ import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.Internal
 
-abstract class ProcessGoogleResourcesTask : Copy() {
+public abstract class ProcessGoogleResourcesTask : Copy() {
     // the Crashlytics plugin needs this property
     @Internal
-    var intermediateDir: File? = null
+    public var intermediateDir: File? = null
 
-    companion object {
+    internal companion object {
         fun Project.registerProcessGoogleResourcesTask(variant: Variant) {
             val variantName = variant.name.capitalize()
             val variantResourceRoot = file(

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/UpdateLicensesTask.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/UpdateLicensesTask.kt
@@ -3,8 +3,8 @@ package com.freeletics.gradle.tasks
 import org.gradle.api.Project
 import org.gradle.api.tasks.Copy
 
-abstract class UpdateLicensesTask : Copy() {
-    companion object {
+public abstract class UpdateLicensesTask : Copy() {
+    internal companion object {
         fun Project.registerUpdateLicensesTask() {
             tasks.register("updateLicenses", UpdateLicensesTask::class.java) { task ->
                 task.from("$buildDir/reports/licensee/release/artifacts.json")

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/AppType.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/AppType.kt
@@ -2,7 +2,7 @@ package com.freeletics.gradle.util
 
 import org.gradle.api.Project
 
-data class AppType(
+internal data class AppType(
     val name: String,
 ) {
     fun minSdkVersion(project: Project): Int? {
@@ -10,11 +10,11 @@ data class AppType(
     }
 }
 
-fun Project.appType(): AppType? {
+internal fun Project.appType(): AppType? {
     return path.toAppType()
 }
 
-fun String.toAppType(): AppType? {
+internal fun String.toAppType(): AppType? {
     if (startsWith(":app:")) {
         return AppType(substringAfter(":app:"))
     }

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 
-interface Git {
+internal interface Git {
     fun branch(): String
     fun commitSha(): String
     fun commitTimestamp(): String
@@ -15,7 +15,7 @@ interface Git {
     fun commitsSince(date: LocalDate): Int
 }
 
-class RealGit(
+internal class RealGit(
     private val rootDir: File,
 ) : Git {
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/ProjectType.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/ProjectType.kt
@@ -2,8 +2,8 @@ package com.freeletics.gradle.util
 
 import org.gradle.api.Project
 
-enum class ProjectType(
-    val fullName: String,
+public enum class ProjectType(
+    internal val fullName: String,
 ) {
     APP(":app:*"),
     CORE_API(":core:*:api"),
@@ -20,11 +20,11 @@ enum class ProjectType(
     LEGACY(":legacy-freeletics:*"),
 }
 
-fun Project.projectType(): ProjectType {
+internal fun Project.projectType(): ProjectType {
     return path.toProjectType()
 }
 
-fun String.toProjectType(): ProjectType {
+internal fun String.toProjectType(): ProjectType {
     return when {
         startsWith(":app:") -> ProjectType.APP
         startsWith(":core:") && endsWith(":api") -> ProjectType.CORE_API

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/String.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/String.kt
@@ -1,3 +1,3 @@
 package com.freeletics.gradle.util
 
-fun String.capitalize() = replaceFirstChar { it.titlecase() }
+internal fun String.capitalize() = replaceFirstChar { it.titlecase() }

--- a/root-plugin/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
+++ b/root-plugin/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
@@ -7,7 +7,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.tasks.Delete
 
-abstract class RootPlugin : Plugin<Project> {
+public abstract class RootPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 

--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
@@ -2,14 +2,14 @@ package com.freeletics.gradle.plugin
 
 import org.gradle.api.initialization.Settings
 
-abstract class SettingsExtension(private val settings: Settings) {
+public abstract class SettingsExtension(private val settings: Settings) {
 
     /**
      * @param androidXBuildId   buildId for androidx snapshot artifacts. Can be taken from here:
      *                          https://androidx.dev/snapshots/builds
      */
     @JvmOverloads
-    fun snapshots(androidXBuildId: String? = null) {
+    public fun snapshots(androidXBuildId: String? = null) {
         settings.dependencyResolutionManagement { management ->
             management.repositories { handler ->
                 handler.maven {
@@ -55,7 +55,7 @@ abstract class SettingsExtension(private val settings: Settings) {
     }
 
     @JvmOverloads
-    fun includeMad(path: String = "../mad") {
+    public fun includeMad(path: String = "../mad") {
         settings.includeBuild(path) { build ->
             build.dependencySubstitution {
                 it.substitute(it.module("com.freeletics.mad:state-machine")).using(it.project(":state-machine"))
@@ -104,7 +104,7 @@ abstract class SettingsExtension(private val settings: Settings) {
     }
 
     @JvmOverloads
-    fun includeFlowRedux(path: String = "../flowredux") {
+    public fun includeFlowRedux(path: String = "../flowredux") {
         settings.includeBuild(path) { build ->
             build.dependencySubstitution {
                 it.substitute(it.module("com.freeletics.flowredux:flowredux")).using(it.project(":flowredux"))

--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
@@ -11,7 +11,7 @@ import org.gradle.kotlin.dsl.jvm
 import org.gradle.toolchains.foojay.FoojayToolchainResolver
 import org.gradle.toolchains.foojay.FoojayToolchainsPlugin
 
-abstract class SettingsPlugin : Plugin<Settings> {
+public abstract class SettingsPlugin : Plugin<Settings> {
 
     override fun apply(target: Settings) {
         target.plugins.apply(FoojayToolchainsPlugin::class.java)


### PR DESCRIPTION
The next release will enforce `explicitApi` on any project using our oss plugin (#24) so this already adds the missing visibility modifiers.