### PR TITLE
add KtLintCli in a new scripts module

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ fl-gradle = "0.2.3"
 
 gradle-api = "8.0.2"
 kotlin = "1.8.20"
+coroutines = "1.6.4"
 android-gradle = "7.4.2"
 ksp="1.8.20-1.0.10"
 anvil = "2.4.4"
@@ -21,6 +22,9 @@ gr8 = "0.8"
 publish = "0.25.1"
 dokka = "1.8.10"
 
+clikt = "3.5.2"
+ktlint = "0.48.2"
+
 junit = "4.13.2"
 truth = "1.1.3"
 
@@ -28,6 +32,7 @@ truth = "1.1.3"
 gradle-api = { module = "dev.gradleplugins:gradle-api", version.ref = "gradle-api" }
 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "coroutines" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 
@@ -47,6 +52,10 @@ gradle-toolchain = { module = "org.gradle.toolchains:foojay-resolver", version.r
 
 gr8 = { module = "com.gradleup:gr8-plugin", version.ref = "gr8" }
 publish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "publish"}
+
+clikt = { module = "com.github.ajalt.clikt:clikt-jvm", version.ref = "clikt" }
+ktlint = { module = "com.pinterest.ktlint:ktlint-core", version.ref = "ktlint" }
+ktlint-rules = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }

--- a/scripts/gradle.properties
+++ b/scripts/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=scripts
+POM_NAME=Scripts
+POM_DESCRIPTION=Collection of kts scripts

--- a/scripts/scripts.gradle
+++ b/scripts/scripts.gradle
@@ -1,0 +1,11 @@
+plugins {
+    alias(libs.plugins.fl.jvm)
+    alias(libs.plugins.fl.publish)
+}
+
+dependencies {
+    api(libs.clikt)
+    implementation(libs.coroutines)
+    implementation(libs.ktlint)
+    implementation(libs.ktlint.rules)
+}

--- a/scripts/src/main/kotlin/com/freeletics/gradle/scripts/FindFiles.kt
+++ b/scripts/src/main/kotlin/com/freeletics/gradle/scripts/FindFiles.kt
@@ -1,0 +1,50 @@
+package com.freeletics.gradle.scripts
+
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.filter
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitResult
+import java.nio.file.Path
+import java.nio.file.PathMatcher
+import kotlin.io.path.ExperimentalPathApi
+import kotlin.io.path.isHidden
+import kotlin.io.path.name
+import kotlin.io.path.visitFileTree
+
+internal val kotlinMatcher = FileSystems.getDefault().getPathMatcher("glob:**/*.{kt,kts}")
+
+@OptIn(ExperimentalPathApi::class)
+internal fun filesToFormat(
+    files: List<Path>?,
+    rootDirectory: Path,
+    matcher: PathMatcher,
+): Flow<Path> {
+    if (files != null) {
+        return files.asFlow().filter { matcher.matches(it.fileName) }
+    }
+
+    return channelFlow {
+        rootDirectory.visitFileTree {
+            onPreVisitDirectory { it, _ ->
+                val name = it.name
+                if (it.isHidden() && name != ".") {
+                    FileVisitResult.SKIP_SUBTREE
+                } else if (name == "build" || name == "res") {
+                    FileVisitResult.SKIP_SUBTREE
+                } else {
+                    FileVisitResult.CONTINUE
+                }
+            }
+
+            onVisitFile { file, _ ->
+                if (matcher.matches(file)) {
+                    check(trySendBlocking(file).isSuccess)
+                }
+                FileVisitResult.CONTINUE
+            }
+        }
+    }
+}

--- a/scripts/src/main/kotlin/com/freeletics/gradle/scripts/KtLintCli.kt
+++ b/scripts/src/main/kotlin/com/freeletics/gradle/scripts/KtLintCli.kt
@@ -1,0 +1,81 @@
+package com.freeletics.gradle.scripts
+
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.split
+import com.github.ajalt.clikt.parameters.types.path
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.io.path.absolute
+import kotlin.system.exitProcess
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.runBlocking
+
+public class KtLintCli : CliktCommand(
+    help = "CLI that runs ktlint."
+) {
+    private val rootDirectory: Path by option(
+        "--root",
+        help = "The root directory of the project, used as starting point to search files and to find editorconfig. " +
+                "Uses current directory if not specified"
+    ).path().default(Paths.get(".").absolute())
+
+    private val files: List<Path>? by option(
+        "--files",
+        help = "The files to format, if not specified all kt/kts files in the current directory and its " +
+                "subdirectories will be formatted."
+    ).path().split(Regex("[\n ,]"))
+
+    private val verify: Boolean by option(
+        "--fail-on-changes",
+        help = "When this flag is passed, the script will fail if any files changed during formatting"
+    ).flag()
+
+    private val init: Boolean by option(
+        "--init",
+        help = "When this flag is passed, the script will do nothing. Can be used to eagerly compile it"
+    ).flag()
+
+    @OptIn(FlowPreview::class)
+    override fun run() = runBlocking(Dispatchers.IO) {
+        if (init) {
+            return@runBlocking
+        }
+
+        val formatter = KtLintFormatter(rootDirectory.resolve(".editorconfig"))
+
+        var count = 0
+        var hadChanges = false
+        var hadErrors = false
+
+        filesToFormat(files, rootDirectory, kotlinMatcher)
+            .onEach { count++ }
+            .flatMapMerge { formatter.format(it) }
+            .collect {
+                if (it.corrected) {
+                    hadChanges = true
+                    if (verify) {
+                        it.print(prefix = "e: (corrected)")
+                    } else {
+                        it.print(prefix = "corrected:")
+                    }
+                } else {
+                    hadErrors = true
+                    it.print(prefix = "e:")
+                }
+            }
+
+        println("Formatted $count files")
+
+        if (hadErrors || (verify && hadChanges)) {
+            // fail
+            exitProcess(1)
+        }
+    }
+}

--- a/scripts/src/main/kotlin/com/freeletics/gradle/scripts/KtLintError.kt
+++ b/scripts/src/main/kotlin/com/freeletics/gradle/scripts/KtLintError.kt
@@ -1,0 +1,14 @@
+package com.freeletics.gradle.scripts
+
+import com.pinterest.ktlint.core.LintError
+import java.nio.file.Path
+
+internal data class KtLintError(
+    val file: Path,
+    val error: LintError,
+    val corrected: Boolean
+) {
+    fun print(prefix: String) {
+        println("$prefix: ${file}:${error.line} ${error.ruleId} ${error.detail}")
+    }
+}

--- a/scripts/src/main/kotlin/com/freeletics/gradle/scripts/KtLintFormatter.kt
+++ b/scripts/src/main/kotlin/com/freeletics/gradle/scripts/KtLintFormatter.kt
@@ -1,0 +1,38 @@
+package com.freeletics.gradle.scripts
+
+import com.pinterest.ktlint.core.KtLintRuleEngine
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.core.api.EditorConfigDefaults
+import com.pinterest.ktlint.core.api.KtLintParseException
+import com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider
+import kotlinx.coroutines.channels.trySendBlocking
+import kotlinx.coroutines.flow.channelFlow
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+internal class KtLintFormatter(
+    editorConfig: Path,
+) {
+    private val engine = KtLintRuleEngine(
+        ruleProviders = StandardRuleSetProvider().getRuleProviders(),
+        editorConfigDefaults = EditorConfigDefaults.load(editorConfig),
+    )
+
+    internal fun format(path: Path) = channelFlow {
+        try {
+            val formattedContent = engine.format(path) { error, corrected ->
+                check(trySendBlocking(KtLintError(path, error, corrected)).isSuccess)
+            }
+            path.writeText(formattedContent)
+        } catch (e: KtLintParseException) {
+            val error = LintError(
+                line = e.line,
+                col = e.col,
+                ruleId = "file-parsing",
+                detail = e.message ?: "Failed to parse file",
+                canBeAutoCorrected = false
+            )
+            check(trySendBlocking(KtLintError(path, error, false)).isSuccess)
+        }
+    }
+}


### PR DESCRIPTION
Moves our existing internal script to a library. This can then be used in a kts script like this:

```
#!/usr/bin/env kotlin

@file:DependsOn("com.freeletics.gradle:scripts:0.3.0")

import com.freeletics.gradle.scripts.KtLintCli

KtLintCli().main(args)
```

This makes it easier to use it across repos without copying code.