### PR TITLE
configure KotlinCompilationTask instead of KotlinCompile

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -21,7 +21,7 @@ public abstract class FreeleticsBaseExtension(protected val project: Project) {
 
     fun optIn(vararg optIn: String) {
         project.kotlin {
-            this.compilerOptions(project) {
+            compilerOptions(project) {
                 freeCompilerArgs.addAll(optIn.map { "-opt-in=$it" })
             }
         }

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -11,6 +11,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JvmVendorSpec
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 public abstract class FreeleticsBasePlugin : Plugin<Project> {
@@ -76,7 +77,9 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
             }
 
             compilerOptions(project) {
-                jvmTarget.set(project.jvmTarget)
+                if (this is KotlinJvmCompilerOptions) {
+                    jvmTarget.set(project.jvmTarget)
+                }
                 getVersionOrNull("kotlin-language")?.let {
                     languageVersion.set(KotlinVersion.fromVersion(it))
                 }

--- a/base/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
@@ -8,9 +8,11 @@ import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinProjectExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 public fun Project.java(action: JavaPluginExtension.() -> Unit) {
@@ -32,11 +34,9 @@ public fun Project.kotlinMultiplatform(action: KotlinMultiplatformExtension.() -
 }
 
 @Suppress("UnusedReceiverParameter") // until KGP provides something like this
-public fun KotlinProjectExtension.compilerOptions(project: Project, action: KotlinJvmCompilerOptions.() -> Unit) {
-    project.tasks.withType(KotlinCompile::class.java).configureEach {
-        it.compilerOptions {
-            action()
-        }
+public fun KotlinProjectExtension.compilerOptions(project: Project, action: KotlinCommonCompilerOptions.() -> Unit) {
+    project.tasks.withType(KotlinCompilationTask::class.java).configureEach {
+        it.compilerOptions(action)
     }
 }
 


### PR DESCRIPTION
`KotlinCompile` is doing jvm compilation. `KotlinCompilationTask` is the base class which also includes the js and native tasks. This will make it so that our config is also properly applied to them and that something like `optIn` from our DSL works properly.