### PR TITLE
add exclude for unused dependency warning triggered by KGP 1.8.20

### DIFF
--- a/root-plugin/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
+++ b/root-plugin/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
@@ -61,6 +61,9 @@ public abstract class RootPlugin : Plugin<Project> {
                             // added by the MoshiX plugin
                             "com.squareup.moshi:moshi",
                             "dev.zacsweers.moshix:moshi-sealed-runtime",
+                            // added by KGP since 1.8.20
+                            // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/884
+                            "() -> java.io.File?",
                         )
                     }
 


### PR DESCRIPTION
Just so that we don't need it in each repo.