### PR TITLE
move auto discovery to extension, add property to disable it

### DIFF
--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
@@ -53,7 +53,7 @@ public abstract class SettingsExtension(private val settings: Settings) {
             val buildFile = gradleFiles.single()
             val relativePath = buildFile.parent.substringAfter(rootPath)
             if (relativePath.isNotEmpty()) {
-                val projectName = relativePath.replace("/", ":")
+                val projectName = relativePath.replace(File.pathSeparator, ":")
                 settings.include(projectName)
                 settings.project(projectName).buildFileName = buildFile.name
             }


### PR DESCRIPTION
We saw a huge increase in the initialisation time of Gradle in 8.1 when configuration cache is enabled. This is because Gradle now keeps track of files and directories that were accessed during configuration time and makes them inputs to the config cache. A huge contributing factor for this is our automatic project inclusion.

To resolve this we're making 2 changes here
1. The discovery has been rewritten a bit to access less files. As part of this it will drop support for nesting projects, it will now not search any subdirectories of folders that contain any `*.gradle` file.
2. Adds a Gradle property to disable automatic discovery and adds functions to the extension to enable it. Here we have an extra function that allows specifying folders to search in.

This is the configuration cache report for our monorepo before these changes
![Screenshot 2023-06-26 at 17 14 13](https://github.com/freeletics/freeletics-gradle-plugins/assets/1358105/a4a27295-ef45-4370-9085-a8071a6c52d9)
After change 1
![Screenshot 2023-06-26 at 17 14 18](https://github.com/freeletics/freeletics-gradle-plugins/assets/1358105/8e716652-3d58-432f-bb36-119d8bc245d4)
After change 2 when only including the directories in which we include projects
![Screenshot 2023-06-26 at 17 15 41](https://github.com/freeletics/freeletics-gradle-plugins/assets/1358105/ea2169f5-bc31-4454-a80a-76534c880414)

Change 2 only reduces the inputs by a little but is actually what improves the performance. It seems like listing the root directory has the biggest impact. 

The reason why auto discovery is still on by default is that the impact on our secondary repos is very small so we can keep it for those.
