### PR TITLE
use project naming for mad/fgp

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
@@ -20,7 +20,7 @@ internal fun Project.configureDagger(mode: DaggerMode) {
         add("api", getDependency("inject"))
         add("api", getDependency("anvil-annotations"))
         add("api", getDependency("dagger"))
-        val whetstoneScope = getDependencyOrNull("fl-whetstone-scope")
+        val whetstoneScope = getDependencyOrNull("mad-whetstone-scope")
         if (whetstoneScope != null) {
             add("api", whetstoneScope)
         }
@@ -28,7 +28,7 @@ internal fun Project.configureDagger(mode: DaggerMode) {
 
     if (mode == DaggerMode.ANVIL_WITH_WHETSTONE) {
         dependencies.apply {
-            add("anvil", getDependency("fl-whetstone-compiler"))
+            add("anvil", getDependency("mad-whetstone-compiler"))
         }
     }
 

--- a/common/README.md
+++ b/common/README.md
@@ -60,8 +60,8 @@ dagger = { module = "com.google.dagger:dagger", version = "..." }
 # only for `useDaggerWithComponent()`
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version = "..." }
 # only for `useDaggerWithWhetstone()`
-fl-whetstone-scope = { module = "com.freeletics.mad:whetstone-scope", version = "..." }
-fl-whetstone-compiler = { module = "com.freeletics.mad:whetstone-compiler", version = "..." }
+mad-whetstone-scope = { module = "com.freeletics.mad:whetstone-scope", version = "..." }
+mad-whetstone-compiler = { module = "com.freeletics.mad:whetstone-compiler", version = "..." }
 ```
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 java-target = "11"
 java-toolchain = "19"
 
-fl-gradle = "0.3.4"
+fgp = "0.3.4"
 
 gradle-api = "8.1"
 kotlin = "1.8.22"
@@ -62,11 +62,11 @@ junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
 
 [plugins]
-fl-root = { id = "com.freeletics.gradle.root", version.ref = "fl-gradle" }
-fl-settings = { id = "com.freeletics.gradle.settings", version.ref = "fl-gradle" }
-fl-gradle = { id = "com.freeletics.gradle.common.gradle", version.ref = "fl-gradle" }
-fl-jvm = { id = "com.freeletics.gradle.common.jvm", version.ref = "fl-gradle" }
-fl-publish = { id = "com.freeletics.gradle.common.publish.oss", version.ref = "fl-gradle" }
+fgp-root = { id = "com.freeletics.gradle.root", version.ref = "fgp" }
+fgp-settings = { id = "com.freeletics.gradle.settings", version.ref = "fgp" }
+fgp = { id = "com.freeletics.gradle.common.gradle", version.ref = "fgp" }
+fgp-jvm = { id = "com.freeletics.gradle.common.jvm", version.ref = "fgp" }
+fgp-publish = { id = "com.freeletics.gradle.common.publish.oss", version.ref = "fgp" }
 
 android = { id = "com.android.application", version.ref = "android-gradle" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
Instead of using the `fl` prefix it now uses `fgp` and `mad` directly.