### PR TITLE
add easy way to use MAD experimental navigation

### DIFF
--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
@@ -69,7 +69,6 @@ public abstract class SettingsExtension(private val settings: Settings) {
                 }
             }
         }
-
     }
 
     /**


### PR DESCRIPTION
This way you can just add
```
freeletics {
     useMadExperimentalNavigation()
}
```
or 
```
freeletics {
     inludeMad("../mad", true)
}
```
to `settings.gradle` to use the experimental navigation implementation.