### PR TITLE
fix settings plugin

### DIFF
--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
@@ -53,7 +53,7 @@ public abstract class SettingsExtension(private val settings: Settings) {
             val buildFile = gradleFiles.single()
             val relativePath = buildFile.parent.substringAfter(rootPath)
             if (relativePath.isNotEmpty()) {
-                val projectName = relativePath.replace(File.pathSeparator, ":")
+                val projectName = relativePath.replace(File.separator, ":")
                 settings.include(projectName)
                 settings.project(projectName).buildFileName = buildFile.name
             }

--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
@@ -136,7 +136,7 @@ public abstract class SettingsPlugin : Plugin<Settings> {
     }
 
     private fun Settings.stringProperty(name: String): String? {
-        return providers.gradleProperty(name).get()
+        return providers.gradleProperty(name).orNull
     }
 
     private fun Settings.booleanProperty(name: String, default: Boolean): Boolean {


### PR DESCRIPTION
- `File.pathSeparator` is `;`, we need `File.separator`
- accidentally made optional properties in the settings plugin required 