### PR TITLE
improve discoverProjects configuration cache compatibility

### DIFF
--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
@@ -131,7 +131,7 @@ public abstract class SettingsPlugin : Plugin<Settings> {
 
         val autoDiscover = target.booleanProperty("fgp.discoverProjects.automatically", true)
         if (autoDiscover) {
-            extension.discoverProjects()
+            extension.discoverProjects(listOf("gradle", "gradle.kts"))
         }
     }
 


### PR DESCRIPTION
This changes the project discovery in 2 ways:
- Currently we list the contents of a folder and then check if a Gradle build file is among them. WIth this we are changing it to eagerly look into a directory to see if it contains a build file with the expected name. If yes we include that project and never list the contents of the actual project directory (e.g. for :core:foo:api we list `core` and `core/foo` but never `core/foo/api`). This way creating or deleting a directory/file inside `core/foo/api` will not invalidate the configuration cache. In practice the first build would create the `build` directory and invalidate the cache for the second build. The small downside is that Gradle will keep track of the existence of build files in the intermediate directories which will never exist (e.g. it checks for a `core/core.gradle` and a `core/foo/core-foo.gradle`).
- Limit how deep we search in folders. We already stop don't go into hidden directories, folders with certain names and stop when a build file is found. This additionally adds a limit on depth to avoid searching for something that doesn't exist.

