### PR TITLE
add method to add Anroid target and option to skip Android native targets

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -275,14 +275,18 @@ The following extension methods make it easy to add multiplatform targets to the
 
 ```groovy
 freeletics {
+    // adds all targets that a also supported by the coroutines project
+    // has a `androidNativeTargets` boolean parameter to control adding androidNative* targets (defaults to enabled)
+    addCommonTargets()
     // adds jvm as a target
     addJvmTarget()
+    // adds Android as a target and automatically adds the Android Library plugin and common Android config
+    // has a `publish` boolean parameter to control adding whether the target should be published (defaults to enabled)
+    addAndroidTarget()
     // adds `iosArm64`, `iosX64`, `iosSimulatorArm64` as targets and creates shared iosMain and iosTest source sets
     addIosTargets("frameworkName")
     // same as above but will also configure everything to create a XCFramework
     addIosTargets("frameworkName", true)
-    // adds all targets that a also supported by the coroutines project
-    addCommonTargets()
 }
 ```
 

--- a/common/common.gradle.kts
+++ b/common/common.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     compileOnly(libs.gr8)
     compileOnly(libs.publish)
 
+    add("shadeClassPath", libs.android.gradle)
     add("shadeClassPath", libs.android.gradle.api)
     add("shadeClassPath", libs.ksp)
     add("shadeClassPath", libs.anvil.gradle)

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -21,7 +21,7 @@ public abstract class FreeleticsMultiplatformExtension(project: Project) : Freel
     @JvmOverloads
     public fun addAndroidTarget(
         publish: Boolean = false,
-        configure: KotlinAndroidTarget.() -> Unit = { }
+        configure: KotlinAndroidTarget.() -> Unit = { },
     ) {
         project.plugins.apply("com.android.library")
         project.plugins.apply(FreeleticsAndroidBasePlugin::class.java)

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -4,6 +4,7 @@ import com.freeletics.gradle.util.kotlinMultiplatform
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.KotlinJsCompilerType
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFrameworkConfig
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
@@ -14,6 +15,25 @@ public abstract class FreeleticsMultiplatformExtension(project: Project) : Freel
     public fun addJvmTarget(configure: KotlinJvmTarget.() -> Unit = { }) {
         project.kotlinMultiplatform {
             jvm(configure = configure)
+        }
+    }
+
+    @JvmOverloads
+    public fun addAndroidTarget(
+        publish: Boolean = false,
+        configure: KotlinAndroidTarget.() -> Unit = { }
+    ) {
+        project.plugins.apply("com.android.library")
+        project.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
+
+        project.kotlinMultiplatform {
+            android {
+                if (publish) {
+                    publishAllLibraryVariants()
+                }
+
+                configure()
+            }
         }
     }
 
@@ -74,7 +94,7 @@ public abstract class FreeleticsMultiplatformExtension(project: Project) : Freel
         }
     }
 
-    public fun addCommonTargets() {
+    public fun addCommonTargets(androidNativeTargets: Boolean = true) {
         project.kotlinMultiplatform {
             jvm()
 
@@ -104,10 +124,12 @@ public abstract class FreeleticsMultiplatformExtension(project: Project) : Freel
             watchosX64()
             watchosSimulatorArm64()
 
-            androidNativeArm32()
-            androidNativeArm64()
-            androidNativeX86()
-            androidNativeX64()
+            if (androidNativeTargets) {
+                androidNativeArm32()
+                androidNativeArm64()
+                androidNativeX86()
+                androidNativeX64()
+            }
 
             val nativeMain = sourceSets.create("nativeMain") { sourceSet ->
                 sourceSet.dependsOn(sourceSets.getByName("commonMain"))

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
@@ -30,8 +30,10 @@ public abstract class FreeleticsPublishOssPlugin : Plugin<Project> {
                 }
 
                 it.plugins.withId("com.android.library") {
-                    target.tasks.named("javaDocReleaseGeneration").configure { task ->
-                        task.enabled = false
+                    if (!target.plugins.hasPlugin("org.jetbrains.multiplatform")) {
+                        target.tasks.named("javaDocReleaseGeneration").configure { task ->
+                            task.enabled = false
+                        }
                     }
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", ver
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
 android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
 
 ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin",  version.ref = "ksp" }


### PR DESCRIPTION
- `addAndroidTarget` makes it easier to create a multiplatform library which has Android platform specific code
- the `androidNativeTargets` parameter to disable `androidNative*` targets will allow using `addCommonTargets` for multiplatform libraries that use compose runtime which doesn't support them (e.g. flowredux's compose artifact)