### PR TITLE
add new Dagger compiler flag

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
@@ -36,6 +36,7 @@ internal fun Project.configureDagger(mode: DaggerMode) {
         val processorConfiguration = configureProcessing(
             "dagger.experimentalDaggerErrorMessages" to "enabled",
             "dagger.strictMultibindingValidation" to "enabled",
+            "dagger.warnIfInjectionFactoryNotGeneratedUpstream" to "enabled",
         )
 
         dependencies.apply {


### PR DESCRIPTION
Adds new flag that was added in Dagger 2.47 to help with the KSP migration https://dagger.dev/dev-guide/compiler-options#ignore-provision-key-wildcards