### PR TITLE
use ksp for room and change flag for dagger

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -15,7 +15,7 @@ import org.gradle.api.Project
 public abstract class FreeleticsAndroidExtension(project: Project) : FreeleticsBaseExtension(project) {
 
     fun useRoom() {
-        val processorConfiguration = project.configureProcessing()
+        val processorConfiguration = project.configureProcessing(useKsp = true)
 
         project.dependencies.apply {
             add("api", project.getDependency("androidx-room-runtime"))

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
@@ -1,6 +1,7 @@
 package com.freeletics.gradle.setup
 
 import com.freeletics.gradle.plugin.FreeleticsBaseExtension.DaggerMode
+import com.freeletics.gradle.util.booleanProperty
 import com.freeletics.gradle.util.getDependency
 import com.freeletics.gradle.util.getDependencyOrNull
 import com.squareup.anvil.plugin.AnvilExtension
@@ -32,8 +33,10 @@ internal fun Project.configureDagger(mode: DaggerMode) {
         }
     }
 
+    val useKsp = booleanProperty("fgp.kotlin.daggerKsp", false)
     if (mode == DaggerMode.ANVIL_WITH_FULL_DAGGER) {
         val processorConfiguration = configureProcessing(
+            useKsp = useKsp.get(),
             "dagger.experimentalDaggerErrorMessages" to "enabled",
             "dagger.strictMultibindingValidation" to "enabled",
             "dagger.warnIfInjectionFactoryNotGeneratedUpstream" to "enabled",

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/ProcessingSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/ProcessingSetup.kt
@@ -1,6 +1,5 @@
 package com.freeletics.gradle.setup
 
-import com.freeletics.gradle.util.booleanProperty
 import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/ProcessingSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/ProcessingSetup.kt
@@ -5,9 +5,8 @@ import com.google.devtools.ksp.gradle.KspExtension
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
 
-public fun Project.configureProcessing(vararg arguments: Pair<String, String>): String {
-    val useKsp = booleanProperty("fgp.kotlin.ksp", true)
-    if (useKsp.get()) {
+public fun Project.configureProcessing(useKsp: Boolean, vararg arguments: Pair<String, String>): String {
+    if (useKsp) {
         plugins.apply("com.google.devtools.ksp")
 
         if (arguments.isNotEmpty()) {


### PR DESCRIPTION
Since we need to use ksp for generating moshi proguard rules now we can also start using it for room. I've changed the ksp gradle property to be dagger specific and default to false.