### PR TITLE
add flags to use Moshi, Anvil and Khonshu with KSP

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
@@ -17,7 +17,7 @@ internal fun Project.configureDagger(mode: DaggerMode) {
         // only full dagger modules use dagger compiler all others use anvil to generate factories
         generateDaggerFactories = mode != DaggerMode.ANVIL_WITH_FULL_DAGGER,
         // we ony do component merging when using dagger to generate components
-        disableComponentMerging = mode != DaggerMode.ANVIL_WITH_FULL_DAGGER
+        disableComponentMerging = mode != DaggerMode.ANVIL_WITH_FULL_DAGGER,
     )
 
     dependencies.apply {

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/MoshiSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/MoshiSetup.kt
@@ -1,12 +1,29 @@
 package com.freeletics.gradle.setup
 
+import com.freeletics.gradle.util.booleanProperty
+import com.freeletics.gradle.util.getDependency
 import dev.zacsweers.moshix.ir.gradle.MoshiPluginExtension
 import org.gradle.api.Project
 
 internal fun Project.configureMoshi(sealed: Boolean) {
-    plugins.apply("dev.zacsweers.moshix")
+    val moshiKsp = booleanProperty("fgp.kotlin.moshiKsp", false)
 
-    extensions.configure(MoshiPluginExtension::class.java) {
-        it.enableSealed.set(sealed)
+    if (moshiKsp.get()) {
+        configureProcessing(useKsp = true)
+
+        dependencies.apply {
+            add("implementation", getDependency("moshi"))
+            add("ksp", getDependency("moshi-codegen"))
+            if (sealed) {
+                add("implementation", getDependency("moshix"))
+                add("ksp", getDependency("moshix-codegen"))
+            }
+        }
+    } else {
+        plugins.apply("dev.zacsweers.moshix")
+
+        extensions.configure(MoshiPluginExtension::class.java) {
+            it.enableSealed.set(sealed)
+        }
     }
 }


### PR DESCRIPTION
- `fgp.kotlin.moshiKsp=true` will use the KSP codegen for Moshi and MoshiX Sealed instead of the IR compiler plugin. This is just meant for testing purposes, I want to compare the performance.
- `fgp.kotlin.anvilKsp=true` will apply ksp and add the Anvil compiler to the KSP configuration instead of applying the Anvil Gradle plugin. This is not functional yet and just added now the switch in the future easier.
- `fgp.kotlin.khonshuKsp` is also for the future and adds Khonshu as a KSP processor instead of an Anvil plugin.