### PR TITLE
add extension method to access SettingsExtension from kts build files

### DIFF
--- a/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
+++ b/settings-plugin/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
@@ -3,6 +3,10 @@ package com.freeletics.gradle.plugin
 import java.io.File
 import org.gradle.api.initialization.Settings
 
+public fun Settings.freeletics(configure: SettingsExtension.() -> Unit) {
+    extensions.configure(SettingsExtension::class.java, configure)
+}
+
 public abstract class SettingsExtension(private val settings: Settings) {
 
     /**


### PR DESCRIPTION
Gradle doesn't seem to automatically generate this for settings plugins, so we add it manually. This allows using
```
freeletics {
    // ...
}
```
in `settings.gradle.kts` instead of having to do `extensions.configure(SettingsExtension::class.java) { ... }`