### PR TITLE
split extensions

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidBasePlugin.kt
@@ -9,6 +9,7 @@ import com.freeletics.gradle.util.android
 import com.freeletics.gradle.util.androidComponents
 import com.freeletics.gradle.util.androidResources
 import com.freeletics.gradle.util.dataBinding
+import com.freeletics.gradle.util.freeleticsExtension
 import com.freeletics.gradle.util.getDependencyOrNull
 import com.freeletics.gradle.util.getVersion
 import com.freeletics.gradle.util.getVersionOrNull
@@ -22,6 +23,8 @@ public abstract class FreeleticsAndroidBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsBasePlugin::class.java)
+
+        target.freeleticsExtension.extensions.create("android", FreeleticsAndroidExtension::class.java)
 
         target.androidSetup()
         target.configureLint()

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -12,7 +12,7 @@ import com.freeletics.gradle.util.kotlin
 import com.freeletics.gradle.util.stringProperty
 import org.gradle.api.Project
 
-public abstract class FreeleticsAndroidExtension(project: Project) : FreeleticsBaseExtension(project) {
+public abstract class FreeleticsAndroidExtension(private val project: Project) {
 
     fun useRoom() {
         val processorConfiguration = project.configureProcessing(useKsp = true)

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -16,6 +16,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 public abstract class FreeleticsBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
+        target.extensions.create("freeletics", FreeleticsExtension::class.java)
+
         target.makeJarsReproducible()
         target.applyPlatformConstraints()
         target.configureJava()

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsExtension.kt
@@ -4,8 +4,9 @@ import com.freeletics.gradle.setup.configureDagger
 import com.freeletics.gradle.setup.configureMoshi
 import com.freeletics.gradle.util.kotlin
 import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
 
-public abstract class FreeleticsBaseExtension(protected val project: Project) {
+public abstract class FreeleticsExtension(private val project: Project) : ExtensionAware {
 
     fun explicitApi() {
         project.kotlin {

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmBasePlugin.kt
@@ -1,6 +1,7 @@
 package com.freeletics.gradle.plugin
 
 import com.freeletics.gradle.setup.defaultTestSetup
+import com.freeletics.gradle.util.freeleticsExtension
 import com.freeletics.gradle.util.java
 import com.freeletics.gradle.util.javaTargetVersion
 import org.gradle.api.Plugin
@@ -12,6 +13,8 @@ public abstract class FreeleticsJvmBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsBasePlugin::class.java)
+
+        target.freeleticsExtension.extensions.create("jvm", FreeleticsJvmExtension::class.java)
 
         target.java {
             sourceCompatibility = target.javaTargetVersion

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmExtension.kt
@@ -3,7 +3,7 @@ package com.freeletics.gradle.plugin
 import com.freeletics.gradle.setup.configureStandaloneLint
 import org.gradle.api.Project
 
-public abstract class FreeleticsJvmExtension(project: Project) : FreeleticsBaseExtension(project) {
+public abstract class FreeleticsJvmExtension(private val project: Project) {
 
     fun useAndroidLint() {
         project.plugins.apply("com.android.lint")

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
@@ -1,6 +1,6 @@
 package com.freeletics.gradle.setup
 
-import com.freeletics.gradle.plugin.FreeleticsBaseExtension.DaggerMode
+import com.freeletics.gradle.plugin.FreeleticsExtension.DaggerMode
 import com.freeletics.gradle.util.booleanProperty
 import com.freeletics.gradle.util.getDependency
 import com.freeletics.gradle.util.getDependencyOrNull

--- a/base/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
@@ -6,10 +6,22 @@ import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.LibraryAndroidComponentsExtension
+import com.freeletics.gradle.plugin.FreeleticsAndroidExtension
+import com.freeletics.gradle.plugin.FreeleticsExtension
+import com.freeletics.gradle.plugin.FreeleticsJvmExtension
 import com.freeletics.gradle.util.KotlinProjectExtensionDelegate.Companion.kotlinProjectExtensionDelegate
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+public val Project.freeleticsExtension
+    get() = extensions.getByType(FreeleticsExtension::class.java)
+
+public val Project.freeleticsAndroidExtension
+    get() = freeleticsExtension.extensions.getByType(FreeleticsAndroidExtension::class.java)
+
+public val Project.freeleticsJvmExtension
+    get() = freeleticsExtension.extensions.getByType(FreeleticsJvmExtension::class.java)
 
 public fun Project.java(action: JavaPluginExtension.() -> Unit) {
     extensions.configure(JavaPluginExtension::class.java) {

--- a/common/README.md
+++ b/common/README.md
@@ -55,8 +55,9 @@ Add the following to the `libs` version catalog:
 [libraries]
 # these will be automatically added as dependencies
 inject = { module = "javax.inject:javax.inject", version = "..." }
-anvil-annotations = { module = "com.squareup.anvil:annotations", version = "..." }
 dagger = { module = "com.google.dagger:dagger", version = "..." }
+anvil-annotations = { module = "com.squareup.anvil:annotations", version = "..." }
+anvil-compiler = { module = "com.squareup.anvil:compiler", version = "..." }
 # only for `useDaggerWithComponent()`
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version = "..." }
 # only for `useDaggerWithKhonshu()`
@@ -136,36 +137,38 @@ The plugin will by default disable most Android build features and offers an ext
 
 ```groovy
 freeletics {
-    // apply the Kotlin parcelize plugin
-    enableParcelize()
-    // enables Compose and configures the compiler
-    // requires `androidx.compose.compiler` to be present in the libs version catalog
-    // supports suppressing the Kotlin version check by setting `fgp.compose.kotlinVersion=<kotlin-version>`
-    enableCompose()
-    // enables Android resource support
-    enableAndroidResources()
-    // enables ViewBinding generation
-    enableViewBinding()
-    // enables BuildConfig generation
-    enableBuildConfig()
-    // create a BuildConfig field with the given value
-    buildConfigField("type", "name", "value")
-    // create a BuildConfig field with separate values for debug and release
-    buildConfigField("type", "name", "debug value", "release value")
-    // enables res values generation
-    enableResValues()
-    // create a res value with the given value
-    resValue("type", "name", "value")
-    // create a res value with separate values for debug and release
-    resValue("type", "name", "debug value", "release value")
-    // enable Android Tests for the debug build type (release will stay disabled)
-    // the parameters are optional
-    enableAndroidTests(
-        "testInstrumentationRunner", // defaults to `androidx.test.runner.AndroidJUnitRunner`
-        "testInstrumentationRunnerArguments", // defaults to `mapOf("clearPackageData" to "'true'")`
-        "execution", // defaults to `ANDROIDX_TEST_ORCHESTRATOR`
-        "animationsDisabled", // defaults to `true`
-    )
+    android {
+        // apply the Kotlin parcelize plugin
+        enableParcelize()
+        // enables Compose and configures the compiler
+        // requires `androidx.compose.compiler` to be present in the libs version catalog
+        // supports suppressing the Kotlin version check by setting `fgp.compose.kotlinVersion=<kotlin-version>`
+        enableCompose()
+        // enables Android resource support
+        enableAndroidResources()
+        // enables ViewBinding generation
+        enableViewBinding()
+        // enables BuildConfig generation
+        enableBuildConfig()
+        // create a BuildConfig field with the given value
+        buildConfigField("type", "name", "value")
+        // create a BuildConfig field with separate values for debug and release
+        buildConfigField("type", "name", "debug value", "release value")
+        // enables res values generation
+        enableResValues()
+        // create a res value with the given value
+        resValue("type", "name", "value")
+        // create a res value with separate values for debug and release
+        resValue("type", "name", "debug value", "release value")
+        // enable Android Tests for the debug build type (release will stay disabled)
+        // the parameters are optional
+        enableAndroidTests(
+                "testInstrumentationRunner", // defaults to `androidx.test.runner.AndroidJUnitRunner`
+                "testInstrumentationRunnerArguments", // defaults to `mapOf("clearPackageData" to "'true'")`
+                "execution", // defaults to `ANDROIDX_TEST_ORCHESTRATOR`
+                "animationsDisabled", // defaults to `true`
+        )
+    }
 }
 ```
 
@@ -175,7 +178,9 @@ To apply the paparazzi plugin and configure it call:
 
 ```groovy
 freeletics {
-    usePaparazzi()
+    android {
+        usePaparazzi()
+    }
 }
 ```
 
@@ -186,10 +191,12 @@ used, to use kapt set this gradle.property: `fgp.kotlin.ksp=false`.
 
 ```groovy
 freeletics {
-    // add room as a dependency and configure kapt/ksp
-    //
-    // requires `androidx-room-runtime` and `androidx-room-compiler` to be present in the version catalog
-    useRoom()
+    android {
+        // add room as a dependency and configure ksp
+        //
+        // requires `androidx-room-runtime` and `androidx-room-compiler` to be present in the version catalog
+        useRoom()
+    }
 }
 ```
 
@@ -234,7 +241,9 @@ To apply the Android Lint plugin and configure it call:
 
 ```groovy
 freeletics {
-    useAndroidLint()
+    jvm {
+        useAndroidLint()
+    }
 }
 ```
 
@@ -277,18 +286,20 @@ The following extension methods make it easy to add multiplatform targets to the
 
 ```groovy
 freeletics {
-    // adds all targets that a also supported by the coroutines project
-    // has a `androidNativeTargets` boolean parameter to control adding androidNative* targets (defaults to enabled)
-    addCommonTargets()
-    // adds jvm as a target
-    addJvmTarget()
-    // adds Android as a target and automatically adds the Android Library plugin and common Android config
-    // has a `publish` boolean parameter to control adding whether the target should be published (defaults to enabled)
-    addAndroidTarget()
-    // adds `iosArm64`, `iosX64`, `iosSimulatorArm64` as targets and creates shared iosMain and iosTest source sets
-    addIosTargets("frameworkName")
-    // same as above but will also configure everything to create a XCFramework
-    addIosTargets("frameworkName", true)
+    multiplatform {
+        // adds all targets that a also supported by the coroutines project
+        // has a `androidNativeTargets` boolean parameter to control adding androidNative* targets (defaults to enabled)
+        addCommonTargets()
+        // adds jvm as a target
+        addJvmTarget()
+        // adds Android as a target and automatically adds the Android Library plugin and common Android config
+        // has a `publish` boolean parameter to control adding whether the target should be published (defaults to enabled)
+        addAndroidTarget(true)
+        // adds `iosArm64`, `iosX64`, `iosSimulatorArm64` as targets and creates shared iosMain and iosTest source sets
+        addIosTargets("frameworkName")
+        // same as above but will also configure everything to create a XCFramework
+        addIosTargets("frameworkName", true)
+    }
 }
 ```
 
@@ -318,8 +329,6 @@ General features:
 plugins {
     id("com.freeletics.gradle.common.gradle").version("<latest-version>")
 }
-
-dependencies
 ```
 
 Add the following to `gradle.properties`:
@@ -384,7 +393,9 @@ To apply the Android Lint plugin and configure it call:
 
 ```groovy
 freeletics {
-    useAndroidLint()
+    jvm {
+        useAndroidLint()
+    }
 }
 ```
 

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
@@ -10,7 +10,5 @@ public abstract class FreeleticsAndroidAppPlugin : Plugin<Project> {
         target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
-
-        target.extensions.create("freeletics", FreeleticsAndroidExtension::class.java)
     }
 }

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
@@ -10,7 +10,5 @@ public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
         target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
-
-        target.extensions.create("freeletics", FreeleticsAndroidExtension::class.java)
     }
 }

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsGradlePluginPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsGradlePluginPlugin.kt
@@ -16,8 +16,6 @@ public abstract class FreeleticsGradlePluginPlugin : Plugin<Project> {
         target.plugins.apply("com.autonomousapps.dependency-analysis")
         target.plugins.apply("com.autonomousapps.plugin-best-practices-plugin")
 
-        target.extensions.create("freeletics", FreeleticsJvmExtension::class.java)
-
         target.kotlin {
             compilerOptions {
                 freeCompilerArgs.add("-Xsam-conversions=class")

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
@@ -9,7 +9,5 @@ public abstract class FreeleticsJvmPlugin : Plugin<Project> {
         target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
-
-        target.extensions.create("freeletics", FreeleticsJvmExtension::class.java)
     }
 }

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFrameworkConfig
 import org.jetbrains.kotlin.gradle.targets.jvm.KotlinJvmTarget
 
-public abstract class FreeleticsMultiplatformExtension(project: Project) : FreeleticsBaseExtension(project) {
+public abstract class FreeleticsMultiplatformExtension(private val project: Project) {
 
     @JvmOverloads
     public fun addJvmTarget(configure: KotlinJvmTarget.() -> Unit = { }) {

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
@@ -1,6 +1,7 @@
 package com.freeletics.gradle.plugin
 
 import com.freeletics.gradle.setup.defaultTestSetup
+import com.freeletics.gradle.util.freeleticsExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.testing.Test
@@ -12,7 +13,7 @@ public abstract class FreeleticsMultiplatformPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        target.extensions.create("freeletics", FreeleticsMultiplatformExtension::class.java)
+        target.freeleticsExtension.extensions.create("multiplatform", FreeleticsMultiplatformExtension::class.java)
 
         target.tasks.withType(Test::class.java).configureEach(Test::defaultTestSetup)
     }

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishOssPlugin.kt
@@ -1,6 +1,7 @@
 package com.freeletics.gradle.plugin
 
 import com.freeletics.gradle.setup.configurePom
+import com.freeletics.gradle.util.freeleticsExtension
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Plugin
@@ -12,8 +13,7 @@ public abstract class FreeleticsPublishOssPlugin : Plugin<Project> {
         target.plugins.apply("org.jetbrains.dokka")
         target.plugins.apply("com.vanniktech.maven.publish")
 
-        val extension = target.extensions.findByName("freeletics") as FreeleticsBaseExtension
-        extension.explicitApi()
+        target.freeleticsExtension.explicitApi()
 
         target.extensions.configure(MavenPublishBaseExtension::class.java) {
             it.publishToMavenCentral(SonatypeHost.DEFAULT, automaticRelease = true)

--- a/monorepo/README.md
+++ b/monorepo/README.md
@@ -17,7 +17,7 @@ specific Gradle plugin.
     - Core modules are split into 2 actual modules, `core:*:api` and `core:*:implementation`. API contains only the
       parts that are used directly by other modules, which in many cases is just an interface. The implementation
       as well as potential Dagger contributions go into the implementation module. This is done to keep
-      implementation classes as well as dependencies only needed by the implementation hidden from consumers of the 
+      implementation classes as well as dependencies only needed by the implementation hidden from consumers of the
       API.
 - `domain`: A Freeletics specific build block that can be used to build features
     - Gradle plugin: `com.freeletics.gradle.domain-android` or `com.freeletics.gradle.domain-kotlin`
@@ -37,19 +37,19 @@ There are rules of which type of module is allowed on which other type:
 *The dotted line means the dependency is optional and only present if needed while a regular line signifies a dependency
 that always exists*
 
-In case the monorepo contains multiple apps the `domain` and `feature` groups can be split up into multiple app specific 
-groups. For that a suffix can be added with a `-` to the top level folder. The suffix should equal the name of the app 
+In case the monorepo contains multiple apps the `domain` and `feature` groups can be split up into multiple app specific
+groups. For that a suffix can be added with a `-` to the top level folder. The suffix should equal the name of the app
 module. For example with `:app:foo` and `:app:bar` anything inside `:domain` and `:feature` can be used by either app
 while `:domain-foo` and `:feature-foo` would be for `:app:foo` and `:domain-bar` and `:feature-bar` for `:app:bar`.
 
-Each module has a `checkDependencyRules` task that will ensure that it only depends on modules that it is allowed to 
+Each module has a `checkDependencyRules` task that will ensure that it only depends on modules that it is allowed to
 depend on based on the rules above. This includes checks based on the module group (e.g. an `implementation` module
-is not allowed to depend on another `implementation` module) and based on the app (e.g. `:app:bar` or 
+is not allowed to depend on another `implementation` module) and based on the app (e.g. `:app:bar` or
 `feature-bar:...:implemenetation` are not allowed to depend on a `domain-foo` module).
 
 ## General config
 
-For the monorepo Gradle plugins to work certain Gradle properties and version catalog entries are required. 
+For the monorepo Gradle plugins to work certain Gradle properties and version catalog entries are required.
 
 Add the following to `gradle.properties`:
 ```properties
@@ -77,7 +77,7 @@ android-target = "34"
 android-compile = "34"
 
 [libraries]
-# if this is present coreLibraryDesugaring will be enabled and this dependency is automatically added 
+# if this is present coreLibraryDesugaring will be enabled and this dependency is automatically added
 android-desugarjdklibs = { module = "com.android.tools:desugar_jdk_libs", version = "..." }
 # default dependencies
 androidx-annotations = { module = "androidx.annotation:annotation", version = "..." }
@@ -109,17 +109,19 @@ Additional features:
 
 ```groovy
 freeletics {
-    // the application id that will be used for the app
-    applicationId("com.example")
-    // sets an application id suffix for the given build type
-    applicationIdSuffix("release", ".suffix")
-    // resources will be limited to the given locales
-    limitLanguagesTo("en", "de", "fr")
-    // enable minification with R8 and use the given proguard files as additional config (parameters are optional)
-    minify(
-        rootProject.file("proguard/library1.pro"),
-        rootProject.file("proguard/library2.pro"),
-    )
+    app {
+        // the application id that will be used for the app
+        applicationId("com.example")
+        // sets an application id suffix for the given build type
+        applicationIdSuffix("release", ".suffix")
+        // resources will be limited to the given locales
+        limitLanguagesTo("en", "de", "fr")
+        // enable minification with R8 and use the given proguard files as additional config (parameters are optional)
+        minify(
+                rootProject.file("proguard/library1.pro"),
+                rootProject.file("proguard/library2.pro"),
+        )
+    }
 }
 ```
 
@@ -128,9 +130,11 @@ freeletics {
 When enabled the `versionName` and `versionCode` will be computed based on information from Git.
 ```groovy
 freeletics {
-    // the passed in value will be used for matching git tags and branches as described below
-    // can be anything identifying an app, e.g. `fl` for `freeletics` or just `freeletics` directly
-    versionFromGit("<short-app-name>")
+    app {
+        // the passed in value will be used for matching git tags and branches as described below
+        // can be anything identifying an app, e.g. `fl` for `freeletics` or just `freeletics` directly
+        versionFromGit("<short-app-name>")
+    }
 }
 ```
 
@@ -140,14 +144,14 @@ The version information can come from:
 - a branch format of `hotfix/<short-app-name>/<app-version>` -> `<app-version>` is used as version name
 - otherwise the output of `git describe` (`<short-app-name>/v<last-app-version>-<commits-since-tag>-<current-commit-sha>`) is used which would result in `<last-app-version>-<commits-since-tag>-<current-commit-sha>`
 
-The version code is then computed by taking the version and applying the following formula 
+The version code is then computed by taking the version and applying the following formula
 ```md
 <major> * 1_000_000 + <minor> * 10_000 + <patch> * 100 + <commits since last week sunday>
 ```
 
 Also creates `BuildConfig.GIT_SHA1`, `BuildConfig.BUILD_TIMESTAMP` fields containing information from the current commit.
 
-To not break incremental builds and build cache `versionName`, `versionCode` and the 2 build config fields will default 
+To not break incremental builds and build cache `versionName`, `versionCode` and the 2 build config fields will default
 to constants. The computation will only happen if `-Pfgp.computeInfoFromGit=true` is passed to the build.
 
 ### License checks
@@ -156,7 +160,9 @@ Applies [Licensee][1] (`app.cash.licensee`) and already configures it to accept 
 
 ```groovy
 freeletics {
-    checkLicenses()
+    app {
+        checkLicenses()
+    }
 }
 ```
 
@@ -174,11 +180,13 @@ when `-Pfgp.computeInfoFromGit=true` is passed to the build.
 
 ```groovy
 freeletics {
-    crashReporting()
+    app {
+        crashReporting()
+    }
 }
 ```
 
-There will also be a generated `BuildConfig.CRASHLYTICS_ENABLED` boolean field that will only be `true` if the mapping 
+There will also be a generated `BuildConfig.CRASHLYTICS_ENABLED` boolean field that will only be `true` if the mapping
 upload was enabled.
 
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppExtension.kt
@@ -23,7 +23,7 @@ import com.freeletics.gradle.util.getVersion
 import java.io.File
 import org.gradle.api.Project
 
-public abstract class AppExtension(project: Project) : FreeleticsAndroidExtension(project) {
+public abstract class AppExtension(private val project: Project) {
 
     public fun applicationId(applicationId: String) {
         project.androidApp {

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppPlugin.kt
@@ -8,6 +8,8 @@ import com.freeletics.gradle.util.ProjectType
 import com.freeletics.gradle.util.androidApp
 import com.freeletics.gradle.util.androidComponents
 import com.freeletics.gradle.util.appType
+import com.freeletics.gradle.util.freeleticsAndroidExtension
+import com.freeletics.gradle.util.freeleticsExtension
 import com.freeletics.gradle.util.stringProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -19,12 +21,12 @@ public abstract class AppPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", AppExtension::class.java)
+        target.freeleticsExtension.extensions.create("app", AppExtension::class.java)
 
-        extension.minSdkVersion(target.appType()?.minSdkVersion(target))
-        extension.enableBuildConfig()
-        extension.enableAndroidResources()
-        extension.enableResValues()
+        target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
+        target.freeleticsAndroidExtension.enableBuildConfig()
+        target.freeleticsAndroidExtension.enableAndroidResources()
+        target.freeleticsAndroidExtension.enableResValues()
 
         target.androidApp {
             signingConfigs {
@@ -67,6 +69,7 @@ public abstract class AppPlugin : Plugin<Project> {
                 baseline = target.file("lint-baseline.xml")
             }
 
+            @Suppress("UnstableApiUsage")
             testOptions {
                 // include test resources in app module to be able to test the manifest
                 unitTests.isIncludeAndroidResources = true

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreAndroidPlugin.kt
@@ -5,6 +5,7 @@ import com.freeletics.gradle.setup.addDefaultDependencies
 import com.freeletics.gradle.setup.addTestDependencies
 import com.freeletics.gradle.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.util.ProjectType
+import com.freeletics.gradle.util.freeleticsAndroidExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -15,9 +16,7 @@ public abstract class CoreAndroidPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", FreeleticsAndroidExtension::class.java)
-
-        extension.enableParcelize()
+        target.freeleticsAndroidExtension.enableParcelize()
 
         target.dependencies.apply {
             addDefaultDependencies(target)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreKotlinPlugin.kt
@@ -4,6 +4,7 @@ import com.freeletics.gradle.setup.addDefaultDependencies
 import com.freeletics.gradle.setup.addTestDependencies
 import com.freeletics.gradle.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.util.ProjectType
+import com.freeletics.gradle.util.freeleticsJvmExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -13,8 +14,7 @@ public abstract class CoreKotlinPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", FreeleticsJvmExtension::class.java)
-        extension.useAndroidLint()
+        target.freeleticsJvmExtension.useAndroidLint()
 
         target.dependencies.apply {
             addDefaultDependencies(target)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidExtension.kt
@@ -1,8 +1,0 @@
-package com.freeletics.gradle.plugin
-
-import org.gradle.api.Project
-
-public abstract class DomainAndroidExtension(project: Project) : FreeleticsAndroidExtension(project) {
-
-    public var allowLegacyDependencies: Boolean = false
-}

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidPlugin.kt
@@ -6,6 +6,8 @@ import com.freeletics.gradle.setup.addTestDependencies
 import com.freeletics.gradle.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.util.ProjectType
 import com.freeletics.gradle.util.appType
+import com.freeletics.gradle.util.freeleticsAndroidExtension
+import com.freeletics.gradle.util.freeleticsExtension
 import com.freeletics.gradle.util.projectType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -17,10 +19,10 @@ public abstract class DomainAndroidPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", DomainAndroidExtension::class.java)
+        val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
 
-        extension.minSdkVersion(target.appType()?.minSdkVersion(target))
-        extension.enableParcelize()
+        target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
+        target.freeleticsAndroidExtension.enableParcelize()
 
         target.dependencies.apply {
             addDefaultDependencies(target)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinExtension.kt
@@ -1,8 +1,0 @@
-package com.freeletics.gradle.plugin
-
-import org.gradle.api.Project
-
-public abstract class DomainKotlinExtension(project: Project) : FreeleticsJvmExtension(project) {
-
-    public var allowLegacyDependencies: Boolean = false
-}

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinPlugin.kt
@@ -4,6 +4,8 @@ import com.freeletics.gradle.setup.addDefaultDependencies
 import com.freeletics.gradle.setup.addTestDependencies
 import com.freeletics.gradle.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.util.ProjectType
+import com.freeletics.gradle.util.freeleticsExtension
+import com.freeletics.gradle.util.freeleticsJvmExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -13,8 +15,9 @@ public abstract class DomainKotlinPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", DomainKotlinExtension::class.java)
-        extension.useAndroidLint()
+        val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
+
+        target.freeleticsJvmExtension.useAndroidLint()
 
         target.dependencies.apply {
             addDefaultDependencies(target)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeatureExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeatureExtension.kt
@@ -1,8 +1,0 @@
-package com.freeletics.gradle.plugin
-
-import org.gradle.api.Project
-
-public abstract class FeatureExtension(project: Project) : FreeleticsAndroidExtension(project) {
-
-    public var allowLegacyDependencies: Boolean = false
-}

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeaturePlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeaturePlugin.kt
@@ -6,6 +6,8 @@ import com.freeletics.gradle.setup.addTestDependencies
 import com.freeletics.gradle.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.util.ProjectType
 import com.freeletics.gradle.util.appType
+import com.freeletics.gradle.util.freeleticsAndroidExtension
+import com.freeletics.gradle.util.freeleticsExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -16,11 +18,11 @@ public abstract class FeaturePlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", FeatureExtension::class.java)
+        val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
 
-        extension.minSdkVersion(target.appType()?.minSdkVersion(target))
-        extension.enableAndroidResources()
-        extension.enableParcelize()
+        target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
+        target.freeleticsAndroidExtension.enableAndroidResources()
+        target.freeleticsAndroidExtension.enableParcelize()
 
         target.dependencies.apply {
             addDefaultDependencies(target)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyAndroidPlugin.kt
@@ -5,6 +5,7 @@ import com.freeletics.gradle.setup.addDefaultDependencies
 import com.freeletics.gradle.setup.addTestDependencies
 import com.freeletics.gradle.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.util.ProjectType
+import com.freeletics.gradle.util.freeleticsAndroidExtension
 import com.freeletics.gradle.util.projectType
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -16,10 +17,8 @@ public abstract class LegacyAndroidPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", FreeleticsAndroidExtension::class.java)
-
-        extension.enableAndroidResources()
-        extension.enableParcelize()
+        target.freeleticsAndroidExtension.enableAndroidResources()
+        target.freeleticsAndroidExtension.enableParcelize()
 
         target.dependencies.apply {
             addDefaultDependencies(target)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyExtension.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyExtension.kt
@@ -1,0 +1,5 @@
+package com.freeletics.gradle.plugin
+
+public abstract class LegacyExtension {
+    public var allowLegacyDependencies: Boolean = false
+}

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyKotlinPlugin.kt
@@ -4,6 +4,7 @@ import com.freeletics.gradle.setup.addDefaultDependencies
 import com.freeletics.gradle.setup.addTestDependencies
 import com.freeletics.gradle.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.util.ProjectType
+import com.freeletics.gradle.util.freeleticsJvmExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -13,8 +14,7 @@ public abstract class LegacyKotlinPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", FreeleticsJvmExtension::class.java)
-        extension.useAndroidLint()
+        target.freeleticsJvmExtension.useAndroidLint()
 
         target.dependencies.apply {
             addDefaultDependencies(target)

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/NavPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/NavPlugin.kt
@@ -6,6 +6,7 @@ import com.freeletics.gradle.setup.addTestDependencies
 import com.freeletics.gradle.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.util.ProjectType
 import com.freeletics.gradle.util.appType
+import com.freeletics.gradle.util.freeleticsAndroidExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -16,10 +17,8 @@ public abstract class NavPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
         target.plugins.apply("com.autonomousapps.dependency-analysis")
 
-        val extension = target.extensions.create("freeletics", FreeleticsAndroidExtension::class.java)
-
-        extension.minSdkVersion(target.appType()?.minSdkVersion(target))
-        extension.enableParcelize()
+        target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
+        target.freeleticsAndroidExtension.enableParcelize()
 
         target.dependencies.apply {
             addDefaultDependencies(target)


### PR DESCRIPTION
Currently `FreeelticsAndroidExtension` and `FreeleticsJvmExtension` are subclasses of `FreeleticsExtension`. If modules have other things they want to add to the Gradle DSL they also subclass one of those 3 and in the end only the final modules register the correct extesion. 

With this change the extensions don't subclass each other anymore and will be registered by the base plugins. So `FreeleticsBasePlugin` registers `FreeleticsExtension`. The android base plugin will then register `FreeelticsAndroidExtension` as a subextension of the freeletics extension. This makes it more flexible and more predictable.

You can see the resulting change on the consumer side in the updated docs. The Android specific parts of the DSL are now inside an `android` block that nested within `freeletics`.