### PR TITLE
improve how Dagger/Anvil KSP options work

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
@@ -16,7 +16,7 @@ internal fun Project.configureDagger(mode: DaggerMode) {
     // apply it at all and let Anvil handle the factory generation. There
     // is no advantage to do that when running Anvil through KSP since KSP
     // is applied anyways so there is no additional overhead for running Dagger.
-    val applyDaggerProcessor = mode == DaggerMode.ANVIL_WITH_FULL_DAGGER || anvilKsp.get()
+    val applyDaggerProcessor = mode == DaggerMode.ANVIL_WITH_FULL_DAGGER || (anvilKsp.get() && daggerKsp.get())
 
     applyAnvil(
         // when Dagger KSP is used, Anvil needs to be used through KSP as well

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/MoshiSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/MoshiSetup.kt
@@ -15,8 +15,8 @@ internal fun Project.configureMoshi(sealed: Boolean) {
             add("implementation", getDependency("moshi"))
             add("ksp", getDependency("moshi-codegen"))
             if (sealed) {
-                add("implementation", getDependency("moshix"))
-                add("ksp", getDependency("moshix-codegen"))
+                add("implementation", getDependency("moshix-sealed"))
+                add("ksp", getDependency("moshix-sealed-codegen"))
             }
         }
     } else {


### PR DESCRIPTION
- When the `daggerKsp` option is enabled and Dagger's processor is applied to the current module also run Anvil through KSP. This leaves the option of only using Anvil KSP where it is required (modules that have `useDaggerWithComponent()` without enabling it for all modules that don't need it (modules that have `useDagger()` or `useDaggerWithKhonshu()`). 
- When `anvilKsp` and `daggerKsp` are enabled apply the Dagger processor and don't let Anvil generate Dagger factories. We currently let Anvil generate factories so that we don't need Dagger and kapt in those modules. If both are running through KSP there is no overhead and we can just let Dagger do its thing.
- Improved naming for moshix sealed dependencies when using moshi through KSP