### PR TITLE
update version logic

### DIFF
--- a/monorepo/README.md
+++ b/monorepo/README.md
@@ -140,14 +140,18 @@ freeletics {
 
 The version information can come from:
 - a tag for the current commit in the format of `<short-app-name>/v<app-version>` -> `<app-version>` is used as version name
-- a branch format of `release/<short-app-name>/<app-version>` -> `<app-version>` is used as version name
-- a branch format of `hotfix/<short-app-name>/<app-version>` -> `<app-version>` is used as version name
 - otherwise the output of `git describe` (`<short-app-name>/v<last-app-version>-<commits-since-tag>-<current-commit-sha>`) is used which would result in `<last-app-version>-<commits-since-tag>-<current-commit-sha>`
 
 The version code is then computed by taking the version and applying the following formula
 ```md
-<major> * 1_000_000 + <minor> * 10_000 + <patch> * 100 + <commits since last week sunday>
+<major> * 1_000_000 + <minor> * 10_000 + <patch>
 ```
+
+For builds on the main branch when the current commit is not tagged, the following formula is used:
+```md
+<major> * 1_000_000 + <minor> * 10_000 + <day_of_week> * 1_000 + <commits since last release>
+```
+
 
 Also creates `BuildConfig.GIT_SHA1`, `BuildConfig.BUILD_TIMESTAMP` fields containing information from the current commit.
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
@@ -2,7 +2,6 @@ package com.freeletics.gradle.tasks
 
 import com.freeletics.gradle.util.Git
 import java.time.LocalDate
-import java.time.temporal.WeekFields
 
 /**
  * Get the app version name, which is computed using the branch name or `git describe`.
@@ -67,7 +66,7 @@ internal fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDa
         checkVersions(major, minor, patch)
 
         // Monday = 1000, Sunday = 7000
-        val dayOfWeek  = localDate.dayOfWeek.value * 1_000
+        val dayOfWeek = localDate.dayOfWeek.value * 1_000
         // the returned version has 7.4.0-32-g5e2416d73f as format where the 32 is the commit count since the tag
         val commitsSinceLastRelease = suffixParts[1].toInt()
         check(commitsSinceLastRelease < 1_000) { "More than 999 commits found since the last release was created" }
@@ -106,11 +105,11 @@ private fun versionFromTag(
     git: Git,
     gitTagName: String,
     initialRelease: Boolean = false,
-    exactMatch: Boolean = false
+    exactMatch: Boolean = false,
 ): String? {
     val patchVersion = if (initialRelease) "0" else "[0-9][0-9]?[0-9]?"
     // match will filter tags to consider based on a regex
-    val describe = git.describe(match = "\"$gitTagName/v[1-9][0-9]\\.[0-9][0-9]*\\.$patchVersion\"\$", exactMatch)
+    val describe = git.describe(match = "\"$gitTagName/v[1-9][0-9]\\.[0-9][0-9]*\\.$patchVersion\$\"", exactMatch)
 
     if (describe.isBlank()) {
         return null

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
@@ -8,10 +8,9 @@ import java.time.temporal.WeekFields
  * Get the app version name, which is computed using the branch name or `git describe`.
  */
 internal fun computeVersionName(git: Git, gitTagName: String): String {
-    return versionFromReleaseOrHotfixBranch(git, gitTagName)
-        ?: versionFromTag(git, gitTagName)
-        // fallback for apps before the first release
-        ?: "0.0.0-${git.commitSha()}"
+    val version = versionFromTag(git, gitTagName)
+    checkNotNull(version) { "Did not find a previous release/tag" }
+    return version
 }
 
 /**
@@ -23,19 +22,14 @@ internal fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDa
     val patch: Int
     val extra: Int
 
-    val version = versionFromReleaseOrHotfixBranch(git, gitTagName) ?: versionFromTag(
-        git,
-        gitTagName,
-        exactMatch = true,
-    )
+    val version = versionFromTag(git, gitTagName, exactMatch = true)
     if (version != null) {
-        // if we are on a release branch or building a tagged commit use the version to compute the version code
+        // if we are building a tagged commit use the version to compute the version code
         //
         // 2_100_000_000 - maximum allowed value
         //    22_xxx_xxx - major version 22
         //    xx_31x_xxx - minor version 31
-        //    xx_xxx_0xx - patch version 0
-        //    xx_xxx_x99 - commit count 99
+        //    xx_xxx_000 - patch version 0
 
         val parts = version.split(".")
         check(parts.size == 3)
@@ -43,20 +37,13 @@ internal fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDa
         minor = parts[1].toInt()
         patch = parts[2].toInt()
         checkVersions(major, minor, patch)
-
-        val releaseCutOffDate = localDate
-            .with(WeekFields.ISO.weekBasedYear(), major + 2_000L)
-            .with(WeekFields.ISO.weekOfWeekBasedYear(), minor.toLong())
-            .with(WeekFields.ISO.dayOfWeek(), 7) // SUNDAY of the week the date is in
-
-        extra = git.commitsSince(releaseCutOffDate)
-        check(extra < 100) { "More than 99 commits found since the release was created" }
+        extra = 0
     } else {
         check(git.branch() == "main") {
-            "Version code can only be computed on main, release and hotfix branches as well as tags"
+            "Version code can only be computed on the main branch and tagged commits"
         }
 
-        // Non release branch and untagged builds will use last week's version for the computed build number.
+        // Untagged builds will use the las last week's version for the computed build number.
         // Patch is always 0 in this case however it will set the digit for thousands at least to 1 (this digit
         // is unused by regular releases). This guarantees that a nighly build will always have a higher build number
         // than last week's release (including hotfixes) but one that is lower than then the release created at the
@@ -65,25 +52,32 @@ internal fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDa
         // 2_100_000_000 - maximum allowed value
         //    22_xxx_xxx - major version 22
         //    xx_31x_xxx - minor version 31
-        //    xx_xx1_099 - commit count 99
+        //    xx_xx1_xxx - day of week
+        //    xx_xxx_099 - commit count 99
 
-        val lastWeek = localDate.minusDays(7)
-            .with(WeekFields.ISO.dayOfWeek(), 7) // SUNDAY of the week the date is in
-
-        major = lastWeek.get(WeekFields.ISO.weekBasedYear()) - 2000
-        minor = lastWeek.get(WeekFields.ISO.weekOfWeekBasedYear())
+        val lastRelease = versionFromTag(git, gitTagName, initialRelease = true)
+        checkNotNull(lastRelease) { "Did not find a previous release/tag" }
+        val versionParts = lastRelease.split(".")
+        check(versionParts.size == 3)
+        val suffixParts = versionParts[2].split("-")
+        check(suffixParts.size == 3)
+        major = versionParts[0].toInt()
+        minor = versionParts[1].toInt()
         patch = 0
         checkVersions(major, minor, patch)
 
-        val commits = git.commitsSince(lastWeek)
-        // add 1000 to the number of commits so that these one
-        extra = commits + 1000
-        check(extra < 10_000) { "More than 8999 commits found since the last release was created" }
+        // Monday = 1000, Sunday = 7000
+        val dayOfWeek  = localDate.dayOfWeek.value * 1_000
+        // the returned version has 7.4.0-32-g5e2416d73f as format where the 32 is the commit count since the tag
+        val commitsSinceLastRelease = suffixParts[1].toInt()
+        check(commitsSinceLastRelease < 1_000) { "More than 999 commits found since the last release was created" }
+
+        extra = dayOfWeek + commitsSinceLastRelease
     }
 
     val versionCode = major * 1_000_000 +
         minor * 10_000 +
-        patch * 100 +
+        patch +
         extra
     check(versionCode < 1_000_000_000) { "Version code should always be lower than 1 billion, was $versionCode" }
 
@@ -95,34 +89,28 @@ private fun checkVersions(major: Int, minor: Int, patch: Int) {
     check(major < 100) { "Major version is limited to 99, was $major" }
     // minor is limited to the number of weeks in a year, so 52 or 53 in practice
     check(minor < 100) { "Minor version is limited to 99, was $minor" }
-    // patch is limited to a single digit, if we need more we have other problems
-    check(patch < 10) { "Patch is limited to 9, was $patch" }
-}
-
-/**
- * If branch is a release or hotfix branch return the last part of the branch name
- * e.g. [branch name] -> [resulting version]
- * release/fl/6.49.0 -> 6.49.0
- * hotfix/fl/7.0.2 -> 7.0.2
- */
-private fun versionFromReleaseOrHotfixBranch(git: Git, gitTagName: String): String? {
-    val branch = git.branch()
-    return if (branch.startsWith("release/$gitTagName/") ||
-        branch.startsWith("hotfix/$gitTagName/")
-    ) {
-        branch.split("/").last()
-    } else {
-        null
-    }
+    // patch is limited to three digits
+    check(patch < 1000) { "Patch is limited to 999, was $patch" }
 }
 
 /**
  * If a tag exists `describe` matches the tag, e.g. `fl/v7.4.0` -> 7.4.0
  * otherwise it's `[tag]-[commits-since-tag]-[current-sha]`, e.g. `fl/v7.4.0-32-g5e2416d73f` -> 7.4.0-32-g5e2416d73f
+ *
+ * The [exactMatch] option makes it so that only the former would be returned and `null` if the current commit
+ * is untagged.
+ *
+ * If [initialRelease] is set to `true` only tags ending in `.0` will be matched.
  */
-private fun versionFromTag(git: Git, gitTagName: String, exactMatch: Boolean = false): String? {
+private fun versionFromTag(
+    git: Git,
+    gitTagName: String,
+    initialRelease: Boolean = false,
+    exactMatch: Boolean = false
+): String? {
+    val patchVersion = if (initialRelease) "0" else "[0-9][0-9]?[0-9]?"
     // match will filter tags to consider based on a regex
-    val describe = git.describe(match = "\"$gitTagName/v[0-9.]*\"", exactMatch)
+    val describe = git.describe(match = "\"$gitTagName/v[1-9][0-9]\\.[0-9][0-9.]?\\.$patchVersion\"\$", exactMatch)
 
     if (describe.isBlank()) {
         return null

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
@@ -42,7 +42,7 @@ public fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDate
             "Version code can only be computed on the main branch and tagged commits"
         }
 
-        // Untagged builds will use the las last week's version for the computed build number.
+        // Untagged builds will use the last version for the computed build number.
         // Patch is always 0 in this case however it will set the digit for thousands at least to 1 (this digit
         // is unused by regular releases). This guarantees that a nighly build will always have a higher build number
         // than last week's release (including hotfixes) but one that is lower than then the release created at the

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
@@ -6,7 +6,7 @@ import java.time.LocalDate
 /**
  * Get the app version name, which is computed using the branch name or `git describe`.
  */
-internal fun computeVersionName(git: Git, gitTagName: String): String {
+public fun computeVersionName(git: Git, gitTagName: String): String {
     val version = versionFromTag(git, gitTagName)
     checkNotNull(version) { "Did not find a previous release/tag" }
     return version
@@ -15,7 +15,7 @@ internal fun computeVersionName(git: Git, gitTagName: String): String {
 /**
  * Get the app version name, which is computed using the branch name or `git describe`.
  */
-internal fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDate): Int {
+public fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDate): Int {
     val major: Int
     val minor: Int
     val patch: Int
@@ -107,9 +107,9 @@ private fun versionFromTag(
     initialRelease: Boolean = false,
     exactMatch: Boolean = false,
 ): String? {
-    val patchVersion = if (initialRelease) "0" else "[0-9][0-9]?[0-9]?"
+    val patchVersion = if (initialRelease) "0" else "[0-9]*"
     // match will filter tags to consider based on a regex
-    val describe = git.describe(match = "\"$gitTagName/v[1-9][0-9]\\.[0-9][0-9]*\\.$patchVersion\$\"", exactMatch)
+    val describe = git.describe(match = "\"$gitTagName/v[1-9][0-9]\\.[0-9]*\\.$patchVersion\"", exactMatch)
 
     if (describe.isBlank()) {
         return null

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/ComputeVersion.kt
@@ -110,7 +110,7 @@ private fun versionFromTag(
 ): String? {
     val patchVersion = if (initialRelease) "0" else "[0-9][0-9]?[0-9]?"
     // match will filter tags to consider based on a regex
-    val describe = git.describe(match = "\"$gitTagName/v[1-9][0-9]\\.[0-9][0-9.]?\\.$patchVersion\"\$", exactMatch)
+    val describe = git.describe(match = "\"$gitTagName/v[1-9][0-9]\\.[0-9][0-9]*\\.$patchVersion\"\$", exactMatch)
 
     if (describe.isBlank()) {
         return null

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
@@ -29,7 +29,6 @@ public class RealGit(
     }
 
     override fun describe(match: String, exactMatch: Boolean): String {
-        println("$match $exactMatch")
         return if (exactMatch) {
             run("describe", "--match", match, "--exact-match")
         } else {

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
@@ -5,14 +5,14 @@ import java.io.IOException
 import java.lang.RuntimeException
 import java.util.concurrent.TimeUnit
 
-internal interface Git {
-    fun branch(): String
-    fun commitSha(): String
-    fun commitTimestamp(): String
-    fun describe(match: String, exactMatch: Boolean): String
+public interface Git {
+    public fun branch(): String
+    public fun commitSha(): String
+    public fun commitTimestamp(): String
+    public fun describe(match: String, exactMatch: Boolean): String
 }
 
-internal class RealGit(
+public class RealGit(
     private val rootDir: File,
 ) : Git {
 
@@ -29,6 +29,7 @@ internal class RealGit(
     }
 
     override fun describe(match: String, exactMatch: Boolean): String {
+        println("$match $exactMatch")
         return if (exactMatch) {
             run("describe", "--match", match, "--exact-match")
         } else {

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
@@ -3,8 +3,6 @@ package com.freeletics.gradle.util
 import java.io.File
 import java.io.IOException
 import java.lang.RuntimeException
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 
 internal interface Git {

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/util/Git.kt
@@ -12,7 +12,6 @@ internal interface Git {
     fun commitSha(): String
     fun commitTimestamp(): String
     fun describe(match: String, exactMatch: Boolean): String
-    fun commitsSince(date: LocalDate): Int
 }
 
 internal class RealGit(
@@ -37,11 +36,6 @@ internal class RealGit(
         } else {
             run("describe", "--match", match)
         }
-    }
-
-    override fun commitsSince(date: LocalDate): Int {
-        val formattedDate = date.format(DateTimeFormatter.ISO_LOCAL_DATE)
-        return run("rev-list", "--count", "HEAD", "--since=\"$formattedDate\"").toInt()
     }
 
     private fun run(vararg command: String): String {

--- a/monorepo/src/test/kotlin/com/freeletics/gradle/tasks/ComputeVersionCodeTest.kt
+++ b/monorepo/src/test/kotlin/com/freeletics/gradle/tasks/ComputeVersionCodeTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 internal class ComputeVersionCodeTest {
 
     @Test
-    fun `when there is a matching tag it returns version computed from it`() {
+    fun `when there is a matching tag it returns version code computed from it`() {
         val git = FakeGit(
             branch = "main",
             describe = "fl/v4.3.1",

--- a/monorepo/src/test/kotlin/com/freeletics/gradle/tasks/ComputeVersionCodeTest.kt
+++ b/monorepo/src/test/kotlin/com/freeletics/gradle/tasks/ComputeVersionCodeTest.kt
@@ -19,16 +19,6 @@ internal class ComputeVersionCodeTest {
     }
 
     @Test
-    fun `when there is a matching tag with extra commits it returns version computed from it`() {
-        val git = FakeGit(
-            branch = "main",
-            describe = "fl/v4.3.1",
-        )
-
-        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(4030001)
-    }
-
-    @Test
     fun `when there is a matching tag and the major version is too high it fails`() {
         val git = FakeGit(
             branch = "main",

--- a/monorepo/src/test/kotlin/com/freeletics/gradle/tasks/ComputeVersionCodeTest.kt
+++ b/monorepo/src/test/kotlin/com/freeletics/gradle/tasks/ComputeVersionCodeTest.kt
@@ -9,170 +9,13 @@ import org.junit.Test
 internal class ComputeVersionCodeTest {
 
     @Test
-    fun `when on a matching release branch it returns version computed from it`() {
-        val git = FakeGit(
-            branch = "release/fl/1.2.0",
-            describe = "fl/v1.0.0",
-            commitsSince = 0,
-        )
-
-        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(1020000)
-    }
-
-    @Test
-    fun `when on a matching release branch with extra commits it returns version computed from it`() {
-        val git = FakeGit(
-            branch = "release/fl/1.2.0",
-            describe = "fl/v1.0.0",
-            commitsSince = 23,
-        )
-
-        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(1020023)
-    }
-
-    @Test
-    fun `when on a matching release branch with too many extra commits it fails`() {
-        val git = FakeGit(
-            branch = "release/fl/1.2.5",
-            describe = "fl/v1.0.0",
-            commitsSince = 100,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("More than 99 commits found since the release was created")
-    }
-
-    @Test
-    fun `when on a matching release branch and the major version is too high it fails`() {
-        val git = FakeGit(
-            branch = "release/fl/100.2.5",
-            describe = "fl/v1.0.0",
-            commitsSince = 0,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("Major version is limited to 99, was 100")
-    }
-
-    @Test
-    fun `when on a matching release branch and the minor version is too high it fails`() {
-        val git = FakeGit(
-            branch = "release/fl/1.100.5",
-            describe = "fl/v1.0.0",
-            commitsSince = 0,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("Minor version is limited to 99, was 100")
-    }
-
-    @Test
-    fun `when on a matching release branch and the patch version is too high it fails`() {
-        val git = FakeGit(
-            branch = "release/fl/1.2.10",
-            describe = "fl/v1.0.0",
-            commitsSince = 0,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("Patch is limited to 9, was 10")
-    }
-
-    @Test
-    fun `when on a matching hotfix branch it returns version computed from it`() {
-        val git = FakeGit(
-            branch = "hotfix/fl/1.2.5",
-            describe = "fl/v1.0.0",
-            commitsSince = 0,
-        )
-
-        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(1020500)
-    }
-
-    @Test
-    fun `when on a matching hotfix branch with extra commits it returns version computed from it`() {
-        val git = FakeGit(
-            branch = "hotfix/fl/1.2.5",
-            describe = "fl/v1.0.0",
-            commitsSince = 23,
-        )
-
-        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(1020523)
-    }
-
-    @Test
-    fun `when on a matching hotfix branch with too many extra commits it fails`() {
-        val git = FakeGit(
-            branch = "hotfix/fl/1.2.5",
-            describe = "fl/v1.0.0",
-            commitsSince = 100,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("More than 99 commits found since the release was created")
-    }
-
-    @Test
-    fun `when on a matching hotifx branch and the major version is too high it fails`() {
-        val git = FakeGit(
-            branch = "hotfix/fl/100.2.1",
-            describe = "fl/v1.0.0",
-            commitsSince = 0,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("Major version is limited to 99, was 100")
-    }
-
-    @Test
-    fun `when on a matching hotifx branch and the minor version is too high it fails`() {
-        val git = FakeGit(
-            branch = "hotfix/fl/1.100.1",
-            describe = "fl/v1.0.0",
-            commitsSince = 0,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("Minor version is limited to 99, was 100")
-    }
-
-    @Test
-    fun `when on a matching hotifx branch and the patch version is too high it fails`() {
-        val git = FakeGit(
-            branch = "hotfix/fl/1.2.10",
-            describe = "fl/v1.0.0",
-            commitsSince = 0,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("Patch is limited to 9, was 10")
-    }
-
-    @Test
     fun `when there is a matching tag it returns version computed from it`() {
         val git = FakeGit(
             branch = "main",
             describe = "fl/v4.3.1",
-            commitsSince = 0,
         )
 
-        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(4030100)
+        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(4030001)
     }
 
     @Test
@@ -180,24 +23,9 @@ internal class ComputeVersionCodeTest {
         val git = FakeGit(
             branch = "main",
             describe = "fl/v4.3.1",
-            commitsSince = 23,
         )
 
-        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(4030123)
-    }
-
-    @Test
-    fun `when there is a matching tag with too many extra commits it fails`() {
-        val git = FakeGit(
-            branch = "main",
-            describe = "fl/v4.3.1",
-            commitsSince = 100,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", LocalDate.now())
-        }
-        assertThat(exception).hasMessageThat().isEqualTo("More than 99 commits found since the release was created")
+        assertThat(computeVersionCode(git, "fl", LocalDate.now())).isEqualTo(4030001)
     }
 
     @Test
@@ -205,7 +33,6 @@ internal class ComputeVersionCodeTest {
         val git = FakeGit(
             branch = "main",
             describe = "fl/v100.3.1",
-            commitsSince = 0,
         )
 
         val exception = assertThrows(IllegalStateException::class.java) {
@@ -219,7 +46,6 @@ internal class ComputeVersionCodeTest {
         val git = FakeGit(
             branch = "main",
             describe = "fl/v4.100.1",
-            commitsSince = 0,
         )
 
         val exception = assertThrows(IllegalStateException::class.java) {
@@ -232,86 +58,126 @@ internal class ComputeVersionCodeTest {
     fun `when there is a matching tag and the patch version is too high it fails`() {
         val git = FakeGit(
             branch = "main",
-            describe = "fl/v4.3.10",
-            commitsSince = 0,
+            describe = "fl/v4.3.1000",
         )
 
         val exception = assertThrows(IllegalStateException::class.java) {
             computeVersionCode(git, "fl", LocalDate.now())
         }
-        assertThat(exception).hasMessageThat().isEqualTo("Patch is limited to 9, was 10")
+        assertThat(exception).hasMessageThat().isEqualTo("Patch is limited to 999, was 1000")
     }
 
     @Test
-    fun `when there is no release branch or tag and branch is not main it fails`() {
+    fun `when there is no tag and branch is not main it fails`() {
         val date = LocalDate.of(2022, 11, 4) // friday
         val git = FakeGit(
             branch = "test",
             describe = "",
-            commitsSince = 0,
         )
 
         val exception = assertThrows(IllegalStateException::class.java) {
             computeVersionCode(git, "fl", date)
         }
         assertThat(exception).hasMessageThat().isEqualTo(
-            "Version code can only be computed on main, release and hotfix branches as well as tags",
+            "Version code can only be computed on the main branch and tagged commits",
         )
     }
 
     @Test
-    fun `when there is no release branch or tag it returns version computed from last week's date`() {
+    fun `when there is no tag it returns version computed from last tag, the commit count and day of week - friday`() {
         val date = LocalDate.of(2022, 11, 11) // friday
         val git = FakeGit(
             branch = "main",
             describe = "",
-            commitsSince = 0,
+            describeNonExact = "fl/v22.44.3-45-abcdefgh",
         )
 
-        assertThat(computeVersionCode(git, "fl", date)).isEqualTo(22441000)
+        assertThat(computeVersionCode(git, "fl", date)).isEqualTo(22445045)
     }
 
     @Test
-    fun `when there is no release branch or tag with extra commits it returns version from last week's date`() {
-        val date = LocalDate.of(2022, 11, 11) // friday
+    fun `when there is no tag it returns version computed from last tag, the commit count and day of week - tuesday`() {
+        val date = LocalDate.of(2022, 11, 8) // tuesday
         val git = FakeGit(
             branch = "main",
             describe = "",
-            commitsSince = 23,
+            describeNonExact = "fl/v22.44.3-45-abcdefgh",
         )
 
-        assertThat(computeVersionCode(git, "fl", date)).isEqualTo(22441023)
+        assertThat(computeVersionCode(git, "fl", date)).isEqualTo(22442045)
     }
 
     @Test
-    fun `when there is no release branch or tag with too many extra commits it fails`() {
+    fun `when there is no tag with extra commits it returns version from last tag and day of week`() {
         val date = LocalDate.of(2022, 11, 11) // friday
         val git = FakeGit(
             branch = "main",
             describe = "",
-            commitsSince = 9000,
+            describeNonExact = "fl/v22.44.3-0-abcdefgh",
+        )
+
+        assertThat(computeVersionCode(git, "fl", date)).isEqualTo(22445000)
+    }
+
+    @Test
+    fun `when there is no tag and the major version is too high it fails`() {
+        val git = FakeGit(
+            branch = "main",
+            describe = "",
+            describeNonExact = "fl/v100.44.3-0-abcdefgh",
         )
 
         val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", date)
-        }
-        assertThat(exception).hasMessageThat().isEqualTo(
-            "More than 8999 commits found since the last release was created",
-        )
-    }
-
-    @Test
-    fun `when there is no release branch or tag and year is too high it fails`() {
-        val date = LocalDate.of(2100, 11, 11) // friday
-        val git = FakeGit(
-            branch = "main",
-            describe = "",
-            commitsSince = 0,
-        )
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            computeVersionCode(git, "fl", date)
+            computeVersionCode(git, "fl", LocalDate.now())
         }
         assertThat(exception).hasMessageThat().isEqualTo("Major version is limited to 99, was 100")
+    }
+
+    @Test
+    fun `when there is no tag and the minor version is too high it fails`() {
+        val git = FakeGit(
+            branch = "main",
+            describe = "",
+            describeNonExact = "fl/v22.100.3-0-abcdefgh",
+        )
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            computeVersionCode(git, "fl", LocalDate.now())
+        }
+        assertThat(exception).hasMessageThat().isEqualTo("Minor version is limited to 99, was 100")
+    }
+
+    @Test
+    fun `when there is no tag and there are too many extra commits it fails`() {
+        val date = LocalDate.of(2022, 11, 11) // friday
+        val git = FakeGit(
+            branch = "main",
+            describe = "",
+            describeNonExact = "fl/v22.44.3-1000-abcdefgh",
+        )
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            computeVersionCode(git, "fl", date)
+        }
+        assertThat(exception).hasMessageThat().isEqualTo(
+            "More than 999 commits found since the last release was created",
+        )
+    }
+
+    @Test
+    fun `when there are no tags at all it fails`() {
+        val date = LocalDate.of(2022, 11, 11) // friday
+        val git = FakeGit(
+            branch = "main",
+            describe = "",
+            describeNonExact = "",
+        )
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            computeVersionCode(git, "fl", date)
+        }
+        assertThat(exception).hasMessageThat().isEqualTo(
+            "Did not find a previous release/tag",
+        )
     }
 }

--- a/monorepo/src/test/kotlin/com/freeletics/gradle/tasks/ComputeVersionNameTest.kt
+++ b/monorepo/src/test/kotlin/com/freeletics/gradle/tasks/ComputeVersionNameTest.kt
@@ -2,83 +2,16 @@ package com.freeletics.gradle.tasks
 
 import com.freeletics.gradle.util.FakeGit
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assert
 import org.junit.Test
 
 internal class ComputeVersionNameTest {
 
     @Test
-    fun `when not on a release or hotfix branch and nothing is tagged it returns version 0 with git sha`() {
-        val git = FakeGit(
-            branch = "main",
-            describe = "",
-        )
-
-        assertThat(computeVersionName(git, "fl")).isEqualTo("0.0.0-abcdefghij")
-    }
-
-    @Test
-    fun `when on a matching release branch it returns version extracted from it`() {
-        val git = FakeGit(
-            branch = "release/fl/1.2.3",
-            describe = "fl/v1.0.0",
-        )
-
-        assertThat(computeVersionName(git, "fl")).isEqualTo("1.2.3")
-    }
-
-    @Test
-    fun `when on a not matching release branch it returns version from tag`() {
-        val git = FakeGit(
-            branch = "release/stdm/1.2.3",
-            describe = "fl/v1.0.0",
-        )
-
-        assertThat(computeVersionName(git, "fl")).isEqualTo("1.0.0")
-    }
-
-    @Test
-    fun `when on a not matching release branch it returns version 0 with git sha`() {
-        val git = FakeGit(
-            branch = "release/stdm/1.2.3",
-        )
-
-        assertThat(computeVersionName(git, "fl")).isEqualTo("0.0.0-abcdefghij")
-    }
-
-    @Test
-    fun `when on a matching hotfix branch it returns version extracted from it`() {
-        val git = FakeGit(
-            branch = "hotfix/fl/1.2.3",
-            describe = "fl/v1.0.0",
-        )
-
-        assertThat(computeVersionName(git, "fl")).isEqualTo("1.2.3")
-    }
-
-    @Test
-    fun `when on a not matching hotfix branch it returns version from tag`() {
-        val git = FakeGit(
-            branch = "hotfix/stdm/1.2.3",
-            describe = "fl/v1.0.0",
-        )
-
-        assertThat(computeVersionName(git, "fl")).isEqualTo("1.0.0")
-    }
-
-    @Test
-    fun `when on a not matching hotfix branch it returns version 0 with git sha`() {
-        val git = FakeGit(
-            branch = "hotfix/stdm/1.2.3",
-        )
-
-        assertThat(computeVersionName(git, "fl")).isEqualTo("0.0.0-abcdefghij")
-    }
-
-    @Test
     fun `when there is a matching tag`() {
         val git = FakeGit(
             branch = "main",
-            describe = "fl/v4.5.6",
+            describeNonExact = "fl/v4.5.6",
         )
 
         assertThat(computeVersionName(git, "fl")).isEqualTo("4.5.6")
@@ -88,9 +21,24 @@ internal class ComputeVersionNameTest {
     fun `when there is a matching tag in the past`() {
         val git = FakeGit(
             branch = "main",
-            describe = "fl/v4.5.6-23-abcdefghij",
+            describeNonExact = "fl/v4.5.6-23-abcdefghij",
         )
 
         assertThat(computeVersionName(git, "fl")).isEqualTo("4.5.6-23-abcdefghij")
+    }
+
+    @Test
+    fun `when there are no tags`() {
+        val git = FakeGit(
+            branch = "main",
+            describeNonExact = "",
+        )
+
+        val exception = Assert.assertThrows(IllegalStateException::class.java) {
+            computeVersionName(git, "fl")
+        }
+        assertThat(exception).hasMessageThat().isEqualTo(
+            "Did not find a previous release/tag",
+        )
     }
 }

--- a/monorepo/src/test/kotlin/com/freeletics/gradle/util/FakeGit.kt
+++ b/monorepo/src/test/kotlin/com/freeletics/gradle/util/FakeGit.kt
@@ -1,13 +1,11 @@
 package com.freeletics.gradle.util
 
-import java.time.LocalDate
-
 internal class FakeGit(
     var branch: String = "main",
     var commitSha: String = "abcdefghij",
     var commitTimestamp: String = "2022-10-21 16:36:11 +0200",
     var describe: String = "",
-    var commitsSince: Int = 0,
+    var describeNonExact: String = "",
 ) : Git {
     override fun branch() = branch
 
@@ -15,7 +13,5 @@ internal class FakeGit(
 
     override fun commitTimestamp() = commitTimestamp
 
-    override fun describe(match: String, exactMatch: Boolean) = describe
-
-    override fun commitsSince(date: LocalDate) = commitsSince
+    override fun describe(match: String, exactMatch: Boolean) = if (exactMatch) describe else describeNonExact
 }


### PR DESCRIPTION
- Stops considering branches/branch names for versioning purposes
- Only tags with a matching prefix or the output of `git describe` is used
- Stop counting commits for the build number of tagged builds and use the last 3 digits for `patch`
- For non tagged builds (our nightly builds in practice) the `1_000` that we add is now multiplied by the day of the week and we are counting commits since the last `.0` release
- Removed some fallbacks for when no tag at all exists since we don't need them