### PR TITLE
Revert "Update ktlint to v1 (major)"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ publish = "0.25.3"
 dokka = "1.9.0"
 
 clikt = "4.2.0"
-ktlint = "1.0.0"
+ktlint = "0.50.0"
 
 junit = "4.13.2"
 truth = "1.1.5"


### PR DESCRIPTION
Reverts freeletics/freeletics-gradle-plugins#150

Ktlint 1.0 uses slf4j which is broken in Kotlin scripts right now https://youtrack.jetbrains.com/issue/KT-60813