### PR TITLE
fix config cache for checkDependencyRules

### DIFF
--- a/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/CheckDependencyRulesTask.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/tasks/CheckDependencyRulesTask.kt
@@ -25,10 +25,10 @@ public abstract class CheckDependencyRulesTask : DefaultTask() {
     public abstract val projectPath: Property<String>
 
     @get:Input
-    public abstract val allowedProjectTypes: ListProperty<ProjectType>
+    public abstract val allowedProjectTypes: ListProperty<String>
 
     @get:Input
-    public abstract val allowedDependencyProjectTypes: ListProperty<ProjectType>
+    public abstract val allowedDependencyProjectTypes: ListProperty<String>
 
     @get:Input
     public abstract val artifactIds: Property<ResolvedComponentResult>
@@ -60,8 +60,8 @@ public abstract class CheckDependencyRulesTask : DefaultTask() {
                 checkDependencyRules(
                     projectPath = projectPath,
                     dependencyPath = it.projectPath,
-                    allowedProjectTypes = allowedProjectTypes.get(),
-                    allowedDependencyProjectTypes = allowedDependencyProjectTypes.get(),
+                    allowedProjectTypes = allowedProjectTypes.get().map(ProjectType::valueOf),
+                    allowedDependencyProjectTypes = allowedDependencyProjectTypes.get().map(ProjectType::valueOf),
                 )
             }
             .toList()
@@ -108,11 +108,9 @@ public abstract class CheckDependencyRulesTask : DefaultTask() {
             allowedDependencyProjectTypes: List<ProjectType>,
         ): TaskProvider<CheckDependencyRulesTask> {
             return tasks.register("${configuration.name}CheckDependencyRules", CheckDependencyRulesTask::class.java) {
-                it.projectPath.set(objects.property(String::class.java).value(path))
-                it.allowedProjectTypes.set(objects.listProperty(ProjectType::class.java).value(allowedProjectTypes))
-                it.allowedDependencyProjectTypes.set(
-                    objects.listProperty(ProjectType::class.java).value(allowedDependencyProjectTypes),
-                )
+                it.projectPath.set(path)
+                it.allowedProjectTypes.addAll(allowedProjectTypes.map(ProjectType::name))
+                it.allowedDependencyProjectTypes.addAll(allowedDependencyProjectTypes.map(ProjectType::name))
                 it.artifactIds.set(configuration.incoming.resolutionResult.rootComponent)
                 it.outputFile.set(layout.buildDirectory.file("reports/dependency-rules/${configuration.name}.txt"))
             }


### PR DESCRIPTION
When running `checkDependencyRules` with configuration cache enabled it currently fails with the exception below. It seems to be unable to deserialize a list of enums, so as a workaround we're now passing strings and convert those back to an enum ourselves.

```
org.gradle.api.GradleException: Could not load the value of field `__allowedDependencyProjectTypes__` of task `:app:freeletics:debugCompileClasspathCheckDependencyRules` of type `com.freeletics.gradle.tasks.CheckDependencyRulesTask`.
        at org.gradle.configurationcache.serialization.beans.BeanPropertyReaderKt.readPropertyValue(BeanPropertyReader.kt:112)
        at org.gradle.configurationcache.serialization.beans.BeanPropertyReader.readStateOf(BeanPropertyReader.kt:68)
        at org.gradle.configurationcache.serialization.codecs.TaskNodeCodec$readTask$2.invokeSuspend(TaskNodeCodec.kt:135)
        at org.gradle.configurationcache.serialization.codecs.TaskNodeCodec$readTask$2.invoke(TaskNodeCodec.kt)
        at org.gradle.configurationcache.serialization.codecs.TaskNodeCodec$readTask$2.invoke(TaskNodeCodec.kt)
        at org.gradle.configurationcache.serialization.codecs.TaskNodeCodecKt.withTaskOf(TaskNodeCodec.kt:237)
        at org.gradle.configurationcache.serialization.codecs.TaskNodeCodecKt.access$withTaskOf(TaskNodeCodec.kt:1)
        at org.gradle.configurationcache.serialization.codecs.TaskNodeCodec.readTask(TaskNodeCodec.kt:129)
        at org.gradle.configurationcache.serialization.codecs.TaskNodeCodec.decode(TaskNodeCodec.kt:78)
        at org.gradle.configurationcache.serialization.codecs.BindingsBackedCodec.decode(BindingsBackedCodec.kt:59)
        at org.gradle.configurationcache.serialization.DefaultReadContext.read(Contexts.kt:269)
        at org.gradle.configurationcache.serialization.CodecKt.readNonNull(Codec.kt:96)
        at org.gradle.configurationcache.serialization.codecs.WorkNodeCodec.readNode(WorkNodeCodec.kt:103)
        at org.gradle.configurationcache.serialization.codecs.WorkNodeCodec.readNodes(WorkNodeCodec.kt:86)
        at org.gradle.configurationcache.serialization.codecs.WorkNodeCodec.readWork(WorkNodeCodec.kt:59)
        at org.gradle.configurationcache.ConfigurationCacheState.readWorkGraph(ConfigurationCacheState.kt:458)
        at org.gradle.configurationcache.ConfigurationCacheState.readBuildContent$configuration_cache(ConfigurationCacheState.kt:439)
        at org.gradle.configurationcache.ConfigurationCacheState.readBuildState(ConfigurationCacheState.kt:302)
        at org.gradle.configurationcache.ConfigurationCacheState.readBuildsInTree(ConfigurationCacheState.kt:264)
        at org.gradle.configurationcache.ConfigurationCacheState.readRootBuild(ConfigurationCacheState.kt:235)
        at org.gradle.configurationcache.ConfigurationCacheState.readRootBuildState(ConfigurationCacheState.kt:150)
        at org.gradle.configurationcache.ConfigurationCacheIO$readRootBuildStateFrom$1.invokeSuspend(ConfigurationCacheIO.kt:146)
        at org.gradle.configurationcache.ConfigurationCacheIO$readRootBuildStateFrom$1.invoke(ConfigurationCacheIO.kt)
        at org.gradle.configurationcache.ConfigurationCacheIO$readRootBuildStateFrom$1.invoke(ConfigurationCacheIO.kt)
        at org.gradle.configurationcache.ConfigurationCacheIO$readConfigurationCacheState$2.invokeSuspend(ConfigurationCacheIO.kt:175)
        at org.gradle.configurationcache.ConfigurationCacheIO$readConfigurationCacheState$2.invoke(ConfigurationCacheIO.kt)
        at org.gradle.configurationcache.ConfigurationCacheIO$readConfigurationCacheState$2.invoke(ConfigurationCacheIO.kt)
        at org.gradle.configurationcache.ConfigurationCacheIO$withReadContextFor$1$1$1$1.invokeSuspend(ConfigurationCacheIO.kt:257)
        at org.gradle.configurationcache.ConfigurationCacheIO$withReadContextFor$1$1$1$1.invoke(ConfigurationCacheIO.kt)
        at org.gradle.configurationcache.ConfigurationCacheIO$withReadContextFor$1$1$1$1.invoke(ConfigurationCacheIO.kt)
        at org.gradle.configurationcache.serialization.RunningKt$runReadOperation$2.invokeSuspend(Running.kt:34)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlin.coroutines.ContinuationKt.startCoroutine(Continuation.kt:115)
        at org.gradle.configurationcache.serialization.RunningKt.runToCompletion(Running.kt:56)
        at org.gradle.configurationcache.serialization.RunningKt.runReadOperation(Running.kt:33)
        at org.gradle.configurationcache.ConfigurationCacheIO.withReadContextFor$configuration_cache(ConfigurationCacheIO.kt:256)
        at org.gradle.configurationcache.ConfigurationCacheIO.readConfigurationCacheState(ConfigurationCacheIO.kt:173)
        at org.gradle.configurationcache.ConfigurationCacheIO.readRootBuildStateFrom$configuration_cache(ConfigurationCacheIO.kt:144)
        at org.gradle.configurationcache.DefaultConfigurationCache$loadWorkGraph$1.invoke(DefaultConfigurationCache.kt:372)
        at org.gradle.configurationcache.DefaultConfigurationCache$loadWorkGraph$1.invoke(DefaultConfigurationCache.kt:371)
        at org.gradle.configurationcache.ConfigurationCacheRepository$StoreImpl$useForStateLoad$1.invoke(ConfigurationCacheRepository.kt:174)
        at org.gradle.configurationcache.ConfigurationCacheRepository$StoreImpl$useForStateLoad$1.invoke(ConfigurationCacheRepository.kt:174)
        at org.gradle.configurationcache.ConfigurationCacheRepository$StoreImpl$useForStateLoad$2.invoke(ConfigurationCacheRepository.kt:179)
        at org.gradle.configurationcache.ConfigurationCacheRepository$StoreImpl$useForStateLoad$2.invoke(ConfigurationCacheRepository.kt:178)
        at org.gradle.configurationcache.ConfigurationCacheRepository$withExclusiveAccessToCache$1.create(ConfigurationCacheRepository.kt:261)
        at org.gradle.cache.internal.LockOnDemandCrossProcessCacheAccess.withFileLock(LockOnDemandCrossProcessCacheAccess.java:90)
        at org.gradle.cache.internal.DefaultCacheCoordinator.withFileLock(DefaultCacheCoordinator.java:219)
        at org.gradle.cache.internal.DefaultPersistentDirectoryStore.withFileLock(DefaultPersistentDirectoryStore.java:179)
        at org.gradle.cache.internal.DefaultCacheFactory$ReferenceTrackingCache.withFileLock(DefaultCacheFactory.java:214)
        at org.gradle.configurationcache.ConfigurationCacheRepository.withExclusiveAccessToCache(ConfigurationCacheRepository.kt:259)
        at org.gradle.configurationcache.ConfigurationCacheRepository.access$withExclusiveAccessToCache(ConfigurationCacheRepository.kt:50)
        at org.gradle.configurationcache.ConfigurationCacheRepository$StoreImpl.useForStateLoad(ConfigurationCacheRepository.kt:178)
        at org.gradle.configurationcache.ConfigurationCacheRepository$StoreImpl.useForStateLoad(ConfigurationCacheRepository.kt:174)
        at org.gradle.configurationcache.DefaultConfigurationCache$loadFromCache$result$1.invoke(DefaultConfigurationCache.kt:385)
        at org.gradle.configurationcache.ConfigurationCacheBuildOperationsKt$withOperation$1.call(ConfigurationCacheBuildOperations.kt:60)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
        at org.gradle.configurationcache.ConfigurationCacheBuildOperationsKt.withOperation(ConfigurationCacheBuildOperations.kt:55)
        at org.gradle.configurationcache.ConfigurationCacheBuildOperationsKt.withLoadOperation(ConfigurationCacheBuildOperations.kt:29)
        at org.gradle.configurationcache.DefaultConfigurationCache.loadFromCache(DefaultConfigurationCache.kt:384)
        at org.gradle.configurationcache.DefaultConfigurationCache.loadWorkGraph(DefaultConfigurationCache.kt:371)
        at org.gradle.configurationcache.DefaultConfigurationCache.loadOrScheduleRequestedTasks(DefaultConfigurationCache.kt:130)
        at org.gradle.configurationcache.ConfigurationCacheAwareBuildTreeWorkController$scheduleAndRunRequestedTasks$executionResult$1.apply(ConfigurationCacheAwareBuildTreeWorkController.kt:45)
        at org.gradle.configurationcache.ConfigurationCacheAwareBuildTreeWorkController$scheduleAndRunRequestedTasks$executionResult$1.apply(ConfigurationCacheAwareBuildTreeWorkController.kt:44)
        at org.gradle.composite.internal.DefaultIncludedBuildTaskGraph.withNewWorkGraph(DefaultIncludedBuildTaskGraph.java:112)
        at org.gradle.configurationcache.ConfigurationCacheAwareBuildTreeWorkController.scheduleAndRunRequestedTasks(ConfigurationCacheAwareBuildTreeWorkController.kt:44)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.lambda$scheduleAndRunTasks$1(DefaultBuildTreeLifecycleController.java:68)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.lambda$runBuild$4(DefaultBuildTreeLifecycleController.java:98)
        at org.gradle.internal.model.StateTransitionController.lambda$transition$6(StateTransitionController.java:169)
        at org.gradle.internal.model.StateTransitionController.doTransition(StateTransitionController.java:266)
        at org.gradle.internal.model.StateTransitionController.lambda$transition$7(StateTransitionController.java:169)
        at org.gradle.internal.work.DefaultSynchronizer.withLock(DefaultSynchronizer.java:44)
        at org.gradle.internal.model.StateTransitionController.transition(StateTransitionController.java:169)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.runBuild(DefaultBuildTreeLifecycleController.java:95)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.scheduleAndRunTasks(DefaultBuildTreeLifecycleController.java:68)
        at org.gradle.internal.buildtree.DefaultBuildTreeLifecycleController.scheduleAndRunTasks(DefaultBuildTreeLifecycleController.java:63)
        at org.gradle.tooling.internal.provider.ExecuteBuildActionRunner.run(ExecuteBuildActionRunner.java:31)
        at org.gradle.launcher.exec.ChainingBuildActionRunner.run(ChainingBuildActionRunner.java:35)
        at org.gradle.internal.buildtree.ProblemReportingBuildActionRunner.run(ProblemReportingBuildActionRunner.java:49)
        at org.gradle.launcher.exec.BuildOutcomeReportingBuildActionRunner.run(BuildOutcomeReportingBuildActionRunner.java:65)
        at org.gradle.tooling.internal.provider.FileSystemWatchingBuildActionRunner.run(FileSystemWatchingBuildActionRunner.java:140)
        at org.gradle.launcher.exec.BuildCompletionNotifyingBuildActionRunner.run(BuildCompletionNotifyingBuildActionRunner.java:41)
        at org.gradle.launcher.exec.RootBuildLifecycleBuildActionExecutor.lambda$execute$0(RootBuildLifecycleBuildActionExecutor.java:40)
        at org.gradle.composite.internal.DefaultRootBuildState.run(DefaultRootBuildState.java:123)
        at org.gradle.launcher.exec.RootBuildLifecycleBuildActionExecutor.execute(RootBuildLifecycleBuildActionExecutor.java:40)
        at org.gradle.internal.buildtree.InitDeprecationLoggingActionExecutor.execute(InitDeprecationLoggingActionExecutor.java:58)
        at org.gradle.internal.buildtree.DefaultBuildTreeContext.execute(DefaultBuildTreeContext.java:40)
        at org.gradle.launcher.exec.BuildTreeLifecycleBuildActionExecutor.lambda$execute$0(BuildTreeLifecycleBuildActionExecutor.java:65)
        at org.gradle.internal.buildtree.BuildTreeState.run(BuildTreeState.java:58)
        at org.gradle.launcher.exec.BuildTreeLifecycleBuildActionExecutor.execute(BuildTreeLifecycleBuildActionExecutor.java:65)
        at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor$3.call(RunAsBuildOperationBuildActionExecutor.java:61)
        at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor$3.call(RunAsBuildOperationBuildActionExecutor.java:57)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:204)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$CallableBuildOperationWorker.execute(DefaultBuildOperationRunner.java:199)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:66)
        at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:157)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.execute(DefaultBuildOperationRunner.java:59)
        at org.gradle.internal.operations.DefaultBuildOperationRunner.call(DefaultBuildOperationRunner.java:53)
        at org.gradle.internal.operations.DefaultBuildOperationExecutor.call(DefaultBuildOperationExecutor.java:73)
        at org.gradle.launcher.exec.RunAsBuildOperationBuildActionExecutor.execute(RunAsBuildOperationBuildActionExecutor.java:57)
        at org.gradle.launcher.exec.RunAsWorkerThreadBuildActionExecutor.lambda$execute$0(RunAsWorkerThreadBuildActionExecutor.java:36)
        at org.gradle.internal.work.DefaultWorkerLeaseService.withLocks(DefaultWorkerLeaseService.java:264)
        at org.gradle.internal.work.DefaultWorkerLeaseService.runAsWorkerThread(DefaultWorkerLeaseService.java:128)
        at org.gradle.launcher.exec.RunAsWorkerThreadBuildActionExecutor.execute(RunAsWorkerThreadBuildActionExecutor.java:36)
        at org.gradle.tooling.internal.provider.continuous.ContinuousBuildActionExecutor.execute(ContinuousBuildActionExecutor.java:110)
        at org.gradle.tooling.internal.provider.SubscribableBuildActionExecutor.execute(SubscribableBuildActionExecutor.java:64)
        at org.gradle.internal.session.DefaultBuildSessionContext.execute(DefaultBuildSessionContext.java:46)
        at org.gradle.tooling.internal.provider.BuildSessionLifecycleBuildActionExecuter$ActionImpl.apply(BuildSessionLifecycleBuildActionExecuter.java:92)
        at org.gradle.tooling.internal.provider.BuildSessionLifecycleBuildActionExecuter$ActionImpl.apply(BuildSessionLifecycleBuildActionExecuter.java:80)
        at org.gradle.internal.session.BuildSessionState.run(BuildSessionState.java:69)
        at org.gradle.tooling.internal.provider.BuildSessionLifecycleBuildActionExecuter.execute(BuildSessionLifecycleBuildActionExecuter.java:62)
        at org.gradle.tooling.internal.provider.BuildSessionLifecycleBuildActionExecuter.execute(BuildSessionLifecycleBuildActionExecuter.java:41)
        at org.gradle.tooling.internal.provider.StartParamsValidatingActionExecuter.execute(StartParamsValidatingActionExecuter.java:64)
        at org.gradle.tooling.internal.provider.StartParamsValidatingActionExecuter.execute(StartParamsValidatingActionExecuter.java:32)
        at org.gradle.tooling.internal.provider.SessionFailureReportingActionExecuter.execute(SessionFailureReportingActionExecuter.java:51)
        at org.gradle.tooling.internal.provider.SessionFailureReportingActionExecuter.execute(SessionFailureReportingActionExecuter.java:39)
        at org.gradle.tooling.internal.provider.SetupLoggingActionExecuter.execute(SetupLoggingActionExecuter.java:47)
        at org.gradle.tooling.internal.provider.SetupLoggingActionExecuter.execute(SetupLoggingActionExecuter.java:31)
        at org.gradle.launcher.daemon.server.exec.ExecuteBuild.doBuild(ExecuteBuild.java:65)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.WatchForDisconnection.execute(WatchForDisconnection.java:39)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.ResetDeprecationLogger.execute(ResetDeprecationLogger.java:29)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.RequestStopIfSingleUsedDaemon.execute(RequestStopIfSingleUsedDaemon.java:35)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.ForwardClientInput$2.create(ForwardClientInput.java:78)
        at org.gradle.launcher.daemon.server.exec.ForwardClientInput$2.create(ForwardClientInput.java:75)
        at org.gradle.util.internal.Swapper.swap(Swapper.java:38)
        at org.gradle.launcher.daemon.server.exec.ForwardClientInput.execute(ForwardClientInput.java:75)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.LogAndCheckHealth.execute(LogAndCheckHealth.java:64)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.LogToClient.doBuild(LogToClient.java:63)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.EstablishBuildEnvironment.doBuild(EstablishBuildEnvironment.java:84)
        at org.gradle.launcher.daemon.server.exec.BuildCommandOnly.execute(BuildCommandOnly.java:37)
        at org.gradle.launcher.daemon.server.api.DaemonCommandExecution.proceed(DaemonCommandExecution.java:104)
        at org.gradle.launcher.daemon.server.exec.StartBuildOrRespondWithBusy$1.run(StartBuildOrRespondWithBusy.java:52)
        at org.gradle.launcher.daemon.server.DaemonStateCoordinator$1.run(DaemonStateCoordinator.java:297)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
        at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
```