### PR TITLE
automatically include khonshu codegen and adjust build health rules

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
@@ -3,6 +3,7 @@ package com.freeletics.gradle.setup
 import com.freeletics.gradle.plugin.FreeleticsBaseExtension.DaggerMode
 import com.freeletics.gradle.util.booleanProperty
 import com.freeletics.gradle.util.getDependency
+import com.freeletics.gradle.util.getDependencyOrNull
 import com.squareup.anvil.plugin.AnvilExtension
 import org.gradle.api.Project
 
@@ -30,6 +31,10 @@ internal fun Project.configureDagger(mode: DaggerMode) {
         add("api", getDependency("anvil-annotations"))
         add("api", getDependency("anvil-annotations-optional"))
         add("api", getDependency("dagger"))
+        val khonshuCodegen = getDependencyOrNull("khonshu-codegen-runtime")
+        if (khonshuCodegen != null) {
+            add("api", khonshuCodegen)
+        }
     }
 
     if (mode == DaggerMode.ANVIL_WITH_KHONSHU) {

--- a/common/README.md
+++ b/common/README.md
@@ -59,6 +59,8 @@ dagger = { module = "com.google.dagger:dagger", version = "..." }
 anvil-annotations = { module = "com.squareup.anvil:annotations", version = "..." }
 anvil-annotations-optional = { module = "com.squareup.anvil:annotations-optional", version = "..." }
 anvil-compiler = { module = "com.squareup.anvil:compiler", version = "..." }
+# optional, if present it will be automatically added as a dependency
+khonshu-codegen-runtime = { module = "com.freeletics.khonshu:codegen-runtime", version = "..." }
 # only for `useDaggerWithComponent()`
 dagger-compiler = { module = "com.google.dagger:dagger-compiler", version = "..." }
 # only for `useDaggerWithKhonshu()`

--- a/root-plugin/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
+++ b/root-plugin/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
@@ -46,6 +46,8 @@ public abstract class RootPlugin : Plugin<Project> {
                             // to remove useDagger from the module
                             "javax.inject:javax.inject",
                             "com.squareup.anvil:annotations",
+                            "com.squareup.anvil:annotations-optional",
+                            "com.freeletics.khonshu:codegen-runtime",
                             "com.freeletics.khonshu:codegen-scope",
                             // added by KGP since 1.8.20
                             // https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/issues/884
@@ -58,6 +60,8 @@ public abstract class RootPlugin : Plugin<Project> {
                             // Dagger is always added as "api", but some modules only use it in for example debugApi
                             "javax.inject:javax.inject",
                             "com.squareup.anvil:annotations",
+                            "com.squareup.anvil:annotations-optional",
+                            "com.freeletics.khonshu:codegen-runtime",
                             "com.freeletics.khonshu:codegen-scope",
                             "com.google.dagger:dagger",
                             "com.google.dagger:dagger-compiler",


### PR DESCRIPTION
Enabling Dagger/Anvil/Khonshu now automatically adds the codegen runtime dependency. Build health has been updated to not flag that dependency and also not the new `annotations-optional` from Anvil.