### PR TITLE
add options to easily enable compose compiler metrics/reports

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -5,6 +5,7 @@ import com.freeletics.gradle.setup.configurePaparazzi
 import com.freeletics.gradle.setup.configureProcessing
 import com.freeletics.gradle.util.android
 import com.freeletics.gradle.util.androidResources
+import com.freeletics.gradle.util.booleanProperty
 import com.freeletics.gradle.util.getDependency
 import com.freeletics.gradle.util.getVersion
 import com.freeletics.gradle.util.kotlin
@@ -56,6 +57,40 @@ public abstract class FreeleticsAndroidExtension(private val project: Project) {
                         "-P",
                         "plugin:androidx.compose.compiler.plugins.kotlin:" +
                             "suppressKotlinVersionCompatibilityCheck=$suppressComposeCompilerCheck",
+                    )
+                }
+            }
+        }
+
+        val enableMetrics = project.booleanProperty("fgp.compose.enableCompilerMetrics", false)
+        if (enableMetrics.get()) {
+            val metricsFolderAbsolutePath = project.layout.buildDirectory
+                .file("compose-metrics")
+                .map { it.asFile.absolutePath }
+                .get()
+
+            project.kotlin {
+                compilerOptions {
+                    freeCompilerArgs.addAll(
+                        "-P",
+                        "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$metricsFolderAbsolutePath",
+                    )
+                }
+            }
+        }
+
+        val enableReports = project.booleanProperty("fgp.compose.enableCompilerReports", false)
+        if (enableReports.get()) {
+            val reportsFolderAbsolutePath = project.layout.buildDirectory
+                .file("compose-reports")
+                .map { it.asFile.absolutePath }
+                .get()
+
+            project.kotlin {
+                compilerOptions {
+                    freeCompilerArgs.addAll(
+                        "-P",
+                        "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$reportsFolderAbsolutePath",
                     )
                 }
             }

--- a/common/README.md
+++ b/common/README.md
@@ -141,8 +141,10 @@ freeletics {
         // apply the Kotlin parcelize plugin
         enableParcelize()
         // enables Compose and configures the compiler
-        // requires `androidx.compose.compiler` to be present in the libs version catalog
-        // supports suppressing the Kotlin version check by setting `fgp.compose.kotlinVersion=<kotlin-version>`
+        // - requires `androidx.compose.compiler` to be present in the libs version catalog
+        // - supports suppressing the Kotlin version check by setting `fgp.compose.kotlinVersion=<kotlin-version>`
+        // - set `fgp.compose.enableCompilerMetrics=true` and/or `fgp.compose.enableCompiler=true` to receive compose
+        //   compiler metrics and/or reports, they will be located in the modules build folder
         enableCompose()
         // enables Android resource support
         enableAndroidResources()


### PR DESCRIPTION
See 
- https://github.com/androidx/androidx/blob/androidx-main/compose/compiler/design/compiler-metrics.md
- https://chrisbanes.me/posts/composable-metrics/

Effectively a copy of https://github.com/freeletics/FlowRedux/blob/main/sample/android/sample-android.gradle.kts#L48-L76