### PR TITLE
move applying plugins to the base plugins

### DIFF
--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppBasePlugin.kt
@@ -3,9 +3,10 @@ package com.freeletics.gradle.plugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
+public abstract class FreeleticsAndroidAppBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
+        target.plugins.apply("com.android.application")
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
     }
 }

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidBasePlugin.kt
@@ -22,6 +22,10 @@ import org.gradle.api.tasks.testing.Test
 public abstract class FreeleticsAndroidBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
+        if (!target.plugins.hasPlugin("com.android.application")) {
+            target.plugins.apply("com.android.library")
+        }
+        target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsBasePlugin::class.java)
 
         target.freeleticsExtension.extensions.create("android", FreeleticsAndroidExtension::class.java)

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -16,6 +16,8 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 public abstract class FreeleticsBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
+        target.plugins.apply("com.autonomousapps.dependency-analysis")
+
         target.extensions.create("freeletics", FreeleticsBaseExtension::class.java)
 
         target.makeJarsReproducible()

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmBasePlugin.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmBasePlugin.kt
@@ -12,6 +12,7 @@ import org.gradle.api.tasks.testing.Test
 public abstract class FreeleticsJvmBasePlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
+        target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsBasePlugin::class.java)
 
         target.freeleticsExtension.extensions.create("jvm", FreeleticsJvmExtension::class.java)

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
@@ -6,9 +6,6 @@ import org.gradle.api.Project
 public abstract class FreeleticsAndroidAppPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
-        target.plugins.apply("com.android.application")
-        target.plugins.apply("org.jetbrains.kotlin.android")
-        target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
+        target.plugins.apply(FreeleticsAndroidAppBasePlugin::class.java)
     }
 }

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsGradlePluginPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsGradlePluginPlugin.kt
@@ -10,10 +10,8 @@ public abstract class FreeleticsGradlePluginPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
         target.plugins.apply("java-gradle-plugin")
-        target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
         target.plugins.apply("com.gradleup.gr8")
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
         target.plugins.apply("com.autonomousapps.plugin-best-practices-plugin")
 
         target.kotlin {

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
@@ -6,8 +6,6 @@ import org.gradle.api.Project
 public abstract class FreeleticsJvmPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
-        target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
     }
 }

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -23,7 +23,6 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
         publish: Boolean = false,
         configure: KotlinAndroidTarget.() -> Unit = { },
     ) {
-        project.plugins.apply("com.android.library")
         project.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
 
         project.kotlinMultiplatform {

--- a/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
+++ b/common/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
@@ -11,7 +11,6 @@ public abstract class FreeleticsMultiplatformPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("org.jetbrains.kotlin.multiplatform")
         target.plugins.apply(FreeleticsBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         target.freeleticsExtension.extensions.create("multiplatform", FreeleticsMultiplatformExtension::class.java)
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/AppPlugin.kt
@@ -16,10 +16,7 @@ import org.gradle.api.Project
 
 public abstract class AppPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("com.android.application")
-        target.plugins.apply("org.jetbrains.kotlin.android")
-        target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
+        target.plugins.apply(FreeleticsAndroidAppBasePlugin::class.java)
 
         target.freeleticsExtension.extensions.create("app", AppExtension::class.java)
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreAndroidPlugin.kt
@@ -11,10 +11,7 @@ import org.gradle.api.Project
 
 public abstract class CoreAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("com.android.library")
-        target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         target.freeleticsAndroidExtension.enableParcelize()
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/CoreKotlinPlugin.kt
@@ -10,9 +10,7 @@ import org.gradle.api.Project
 
 public abstract class CoreKotlinPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         target.freeleticsJvmExtension.useAndroidLint()
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainAndroidPlugin.kt
@@ -14,10 +14,7 @@ import org.gradle.api.Project
 
 public abstract class DomainAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("com.android.library")
-        target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/DomainKotlinPlugin.kt
@@ -11,9 +11,7 @@ import org.gradle.api.Project
 
 public abstract class DomainKotlinPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeaturePlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/FeaturePlugin.kt
@@ -13,10 +13,7 @@ import org.gradle.api.Project
 
 public abstract class FeaturePlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("com.android.library")
-        target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyAndroidPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyAndroidPlugin.kt
@@ -12,10 +12,7 @@ import org.gradle.api.Project
 
 public abstract class LegacyAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("com.android.library")
-        target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         target.freeleticsAndroidExtension.enableAndroidResources()
         target.freeleticsAndroidExtension.enableParcelize()

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyKotlinPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/LegacyKotlinPlugin.kt
@@ -10,9 +10,7 @@ import org.gradle.api.Project
 
 public abstract class LegacyKotlinPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("org.jetbrains.kotlin.jvm")
         target.plugins.apply(FreeleticsJvmBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         target.freeleticsJvmExtension.useAndroidLint()
 

--- a/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/NavPlugin.kt
+++ b/monorepo/src/main/kotlin/com/freeletics/gradle/plugin/NavPlugin.kt
@@ -12,10 +12,7 @@ import org.gradle.api.Project
 
 public abstract class NavPlugin : Plugin<Project> {
     override fun apply(target: Project) {
-        target.plugins.apply("com.android.library")
-        target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsAndroidBasePlugin::class.java)
-        target.plugins.apply("com.autonomousapps.dependency-analysis")
 
         target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
         target.freeleticsAndroidExtension.enableParcelize()


### PR DESCRIPTION
Instead of applying the Android and Kotlin plugins in each individual plugin, do that in the base plugins. Reduces the repetition that is currently needed. I'm also planning to merge the common and base plugins since some other changes made that split unnecessary and this is a nice preparation for that since the common plugins are now mostly empty.