### PR TITLE
support compose multiplatform

### DIFF
--- a/base/base.gradle.kts
+++ b/base/base.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     }
     compileOnly(variantOf(libs.kotlin.gradle.api) { classifier("gradle76") })
     compileOnly(libs.android.gradle.api)
+    compileOnly(libs.compose.gradle)
     compileOnly(libs.ksp)
     compileOnly(libs.anvil.gradle)
     compileOnly(libs.moshix.gradle)

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -7,9 +7,6 @@ import com.freeletics.gradle.util.android
 import com.freeletics.gradle.util.androidResources
 import com.freeletics.gradle.util.booleanProperty
 import com.freeletics.gradle.util.getDependency
-import com.freeletics.gradle.util.getVersion
-import com.freeletics.gradle.util.kotlin
-import com.freeletics.gradle.util.stringProperty
 import org.gradle.api.Project
 
 public abstract class FreeleticsAndroidExtension(private val project: Project) {
@@ -41,64 +38,6 @@ public abstract class FreeleticsAndroidExtension(private val project: Project) {
 
     public fun enableParcelize() {
         project.plugins.apply("org.jetbrains.kotlin.plugin.parcelize")
-    }
-
-    public fun enableCompose() {
-        val project = this.project
-        project.android {
-            buildFeatures.compose = true
-
-            composeOptions {
-                kotlinCompilerExtensionVersion = project.getVersion("androidx.compose.compiler")
-            }
-        }
-
-        val suppressComposeCompilerCheck = project.stringProperty("fgp.compose.kotlinVersion").orNull
-        if (suppressComposeCompilerCheck != null) {
-            project.kotlin {
-                compilerOptions {
-                    freeCompilerArgs.addAll(
-                        "-P",
-                        "plugin:androidx.compose.compiler.plugins.kotlin:" +
-                            "suppressKotlinVersionCompatibilityCheck=$suppressComposeCompilerCheck",
-                    )
-                }
-            }
-        }
-
-        val enableMetrics = project.booleanProperty("fgp.compose.enableCompilerMetrics", false)
-        if (enableMetrics.get()) {
-            val metricsFolderAbsolutePath = project.layout.buildDirectory
-                .file("compose-metrics")
-                .map { it.asFile.absolutePath }
-                .get()
-
-            project.kotlin {
-                compilerOptions {
-                    freeCompilerArgs.addAll(
-                        "-P",
-                        "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$metricsFolderAbsolutePath",
-                    )
-                }
-            }
-        }
-
-        val enableReports = project.booleanProperty("fgp.compose.enableCompilerReports", false)
-        if (enableReports.get()) {
-            val reportsFolderAbsolutePath = project.layout.buildDirectory
-                .file("compose-reports")
-                .map { it.asFile.absolutePath }
-                .get()
-
-            project.kotlin {
-                compilerOptions {
-                    freeCompilerArgs.addAll(
-                        "-P",
-                        "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$reportsFolderAbsolutePath",
-                    )
-                }
-            }
-        }
     }
 
     public fun enableViewBinding() {

--- a/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -2,6 +2,7 @@ package com.freeletics.gradle.plugin
 
 import com.freeletics.gradle.setup.configureDagger
 import com.freeletics.gradle.setup.configureMoshi
+import com.freeletics.gradle.setup.setupCompose
 import com.freeletics.gradle.util.kotlin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
@@ -20,6 +21,10 @@ public abstract class FreeleticsBaseExtension(private val project: Project) : Ex
                 optIn.addAll(*classes)
             }
         }
+    }
+
+    public fun useCompose() {
+        project.setupCompose()
     }
 
     @JvmOverloads

--- a/base/src/main/kotlin/com/freeletics/gradle/setup/ComposeSetup.kt
+++ b/base/src/main/kotlin/com/freeletics/gradle/setup/ComposeSetup.kt
@@ -1,0 +1,86 @@
+package com.freeletics.gradle.setup
+
+import com.freeletics.gradle.util.android
+import com.freeletics.gradle.util.booleanProperty
+import com.freeletics.gradle.util.getDependency
+import com.freeletics.gradle.util.getVersion
+import com.freeletics.gradle.util.kotlin
+import com.freeletics.gradle.util.stringProperty
+import org.gradle.api.Project
+import org.jetbrains.compose.ComposeExtension
+
+internal fun Project.setupCompose() {
+    if ((plugins.hasPlugin("com.android.library") || plugins.hasPlugin("com.android.library")) &&
+        !plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
+    ) {
+        setupComposeAndroid()
+    } else {
+        setupComposeJetbrains()
+    }
+
+    val suppressComposeCompilerCheck = project.stringProperty("fgp.compose.kotlinVersion").orNull
+    if (suppressComposeCompilerCheck != null) {
+        project.kotlin {
+            compilerOptions {
+                freeCompilerArgs.addAll(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:" +
+                        "suppressKotlinVersionCompatibilityCheck=$suppressComposeCompilerCheck",
+                )
+            }
+        }
+    }
+
+    val enableMetrics = project.booleanProperty("fgp.compose.enableCompilerMetrics", false)
+    if (enableMetrics.get()) {
+        val metricsFolderAbsolutePath = project.layout.buildDirectory
+            .file("compose-metrics")
+            .map { it.asFile.absolutePath }
+            .get()
+
+        project.kotlin {
+            compilerOptions {
+                freeCompilerArgs.addAll(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$metricsFolderAbsolutePath",
+                )
+            }
+        }
+    }
+
+    val enableReports = project.booleanProperty("fgp.compose.enableCompilerReports", false)
+    if (enableReports.get()) {
+        val reportsFolderAbsolutePath = project.layout.buildDirectory
+            .file("compose-reports")
+            .map { it.asFile.absolutePath }
+            .get()
+
+        project.kotlin {
+            compilerOptions {
+                freeCompilerArgs.addAll(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$reportsFolderAbsolutePath",
+                )
+            }
+        }
+    }
+}
+
+private fun Project.setupComposeAndroid() {
+    project.android {
+        buildFeatures.compose = true
+
+        composeOptions {
+            kotlinCompilerExtensionVersion = project.getVersion("androidx.compose.compiler")
+        }
+    }
+}
+
+private fun Project.setupComposeJetbrains() {
+    plugins.apply("org.jetbrains.compose")
+
+    extensions.configure(ComposeExtension::class.java) {
+        val composeCompiler = getDependency("jetbrains-compose-compiler").get()
+        it.kotlinCompilerPlugin.set("${composeCompiler.group}:${composeCompiler.name}:${composeCompiler.version}")
+    }
+}

--- a/common/README.md
+++ b/common/README.md
@@ -20,6 +20,37 @@ freeletics {
 }
 ```
 
+### Compose
+
+This will enable Compose on the project and works on Android, JVM and multiplatform projects. For the latter 2 the
+`org.jetbrains.compose` plugin needs to be on the classpath.
+
+```groovy
+freeletics {
+    // requires `androidx.compose.compiler` to be present in the libs version catalog
+    // supports suppressing the Kotlin version check by setting `fgp.compose.kotlinVersion=<kotlin-version>`
+    useCompose()
+}
+```
+
+Add the following to the `libs` version catalog:
+```toml
+[libraries]
+# for Android projects
+androidx-compose-compiler = { module = "androidx.compose.compiler:compiler", version = "..." }
+# for non-Android or multiplatform projects
+jetbrains-compose-compiler = { module = "org.jetbrains.compose.compiler:compiler", version = "..." }
+```
+
+There are a few optional Gradle properties for certain compose compiler options:
+```properties
+# Suppress the Kotlin version in the compiler for the given Kotlin version
+fgp.compose.kotlinVersion=<kotlin-version>
+# Set these to enable compiler metrics and/or reports, they will be located in the modules build folder
+fgp.compose.enableCompilerMetrics=true
+fgp.compose.enableCompilerReports=true
+```
+
 ### Moshi
 
 The following method will apply the [MoshiX plugin][2] (`dev.zacsweers.moshix`) which will enable Moshi code generation
@@ -142,12 +173,6 @@ freeletics {
     android {
         // apply the Kotlin parcelize plugin
         enableParcelize()
-        // enables Compose and configures the compiler
-        // - requires `androidx.compose.compiler` to be present in the libs version catalog
-        // - supports suppressing the Kotlin version check by setting `fgp.compose.kotlinVersion=<kotlin-version>`
-        // - set `fgp.compose.enableCompilerMetrics=true` and/or `fgp.compose.enableCompiler=true` to receive compose
-        //   compiler metrics and/or reports, they will be located in the modules build folder
-        enableCompose()
         // enables Android resource support
         enableAndroidResources()
         // enables ViewBinding generation
@@ -182,21 +207,21 @@ freeletics {
 
 ### Room
 
-To easily add room as a dependency and apply KSP or KAPT the following extension method can be used. By default ksp is
-used, to use kapt set this gradle.property: `fgp.kotlin.ksp=false`.
+To easily add room as a dependency and apply KSP the following extension method can be used.
 
 ```groovy
 freeletics {
     android {
-        // add room as a dependency and configure ksp
-        //
-        // requires `androidx-room-runtime` and `androidx-room-compiler` to be present in the version catalog
         useRoom()
     }
 }
 ```
 
-Requires `androidx-room-runtime` and `androidx-room-compiler` to be present in the `libs` version catalog.
+Add the following to the `libs` version catalog:
+```toml
+androidx-room-runtime = { module = "androidx.room:room-runtime", version = "..." }
+androidx-room-compiler = { module = "androidx.room:room-compiler", version = "..." }
+```
 
 
 ## Kotlin/JVM Library projects

--- a/common/common.gradle.kts
+++ b/common/common.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
 
     add("shadeClassPath", libs.android.gradle)
     add("shadeClassPath", libs.android.gradle.api)
+    add("shadeClassPath", libs.compose.gradle)
     add("shadeClassPath", libs.ksp)
     add("shadeClassPath", libs.anvil.gradle)
     add("shadeClassPath", libs.moshix.gradle)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ gradle-api = "8.3"
 kotlin = "1.9.10"
 coroutines = "1.7.3"
 android-gradle = "8.1.1"
+jb-compose="1.5.1"
 ksp="1.9.10-1.0.13"
 anvil = "2.4.8"
 moshix = "0.24.3"
@@ -39,6 +40,7 @@ kotlin-gradle-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", 
 android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
 android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
 
+compose-gradle = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "jb-compose" }
 ksp = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin",  version.ref = "ksp" }
 anvil-gradle = { module = "com.squareup.anvil:gradle-plugin", version.ref = "anvil" }
 moshix-gradle = { module = "dev.zacsweers.moshix:moshi-gradle-plugin", version.ref = "moshix" }

--- a/monorepo/monorepo.gradle.kts
+++ b/monorepo/monorepo.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
         exclude("org.jetbrains.kotlin", "kotlin-gradle-plugin-api")
     }
     add("shadeClassPath", variantOf(libs.kotlin.gradle.api) { classifier("gradle76") })
+    add("shadeClassPath", libs.compose.gradle)
     add("shadeClassPath", libs.ksp)
     add("shadeClassPath", libs.anvil.gradle)
     add("shadeClassPath", libs.moshix.gradle)


### PR DESCRIPTION
Moves `enableCompose()` to the base extension and makes it use the Jetbrains Gradle plugin for non Android projects. The main target for this change is FlowRedux which already has compose in a multiplatform module but it will also make multiplatform experiments easier