### PR TITLE
don't apply Kotlin Android plugin if multiplatform plugin in already applied

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
@@ -25,7 +25,9 @@ public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
         if (!target.plugins.hasPlugin("com.android.application")) {
             target.plugins.apply("com.android.library")
         }
-        target.plugins.apply("org.jetbrains.kotlin.android")
+        if (!target.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
+            target.plugins.apply("org.jetbrains.kotlin.android")
+        }
         target.plugins.apply(FreeleticsBasePlugin::class.java)
 
         target.freeleticsExtension.extensions.create("android", FreeleticsAndroidExtension::class.java)


### PR DESCRIPTION
This fixes an issue when adding an Android target to multiplatform modules. Currently it fails with an exception because you can't apply to Kotlin plugins to the same project.