### PR TITLE
fix annotation on ProcessGoogleResourcesTask

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ProcessGoogleResourcesTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ProcessGoogleResourcesTask.kt
@@ -9,7 +9,7 @@ import org.gradle.api.tasks.Internal
 
 public abstract class ProcessGoogleResourcesTask : Copy() {
     // the Crashlytics plugin needs this property
-    @Internal
+    @get:Internal
     public var intermediateDir: File? = null
 
     internal companion object {


### PR DESCRIPTION
Fixes this issue:
```
A problem was found with the configuration of task ':app:freeletics:processReleaseGoogleServices' (type 'ProcessGoogleResourcesTask').
  - In plugin 'com.freeletics.gradle.plugin.FreeleticsBasePlugin$Inject' type 'com.freeletics.gradle.monorepo.tasks.ProcessGoogleResourcesTask' property 'intermediateDir' is missing an input or output annotation.
    
    Reason: A property without annotation isn't considered during up-to-date checking.
    
    Possible solutions:
      1. Add an input or output annotation.
      2. Mark it as @Internal.
    
    For more information, please refer to https://docs.gradle.org/8.3/userguide/validation_problems.html#missing_annotation in the Gradle documentation.
```

I'm not actually sure why this worked previously, the code didn't change since March