### PR TITLE
make check task depend on checkDependencyRules

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/CheckDependencyRulesTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/CheckDependencyRulesTask.kt
@@ -87,7 +87,7 @@ public abstract class CheckDependencyRulesTask : DefaultTask() {
             allowedDependencyProjectTypes: List<ProjectType>,
         ) {
             val checkDependencyRules = tasks.register("checkDependencyRules")
-            
+
             tasks.named("check").configure {
                 it.dependsOn(checkDependencyRules)
             }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/CheckDependencyRulesTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/CheckDependencyRulesTask.kt
@@ -87,6 +87,10 @@ public abstract class CheckDependencyRulesTask : DefaultTask() {
             allowedDependencyProjectTypes: List<ProjectType>,
         ) {
             val checkDependencyRules = tasks.register("checkDependencyRules")
+            
+            tasks.named("check").configure {
+                it.dependsOn(checkDependencyRules)
+            }
 
             configurations.configureEach {
                 if (it.name.contains("compileClasspath", ignoreCase = true)) {


### PR DESCRIPTION
This makes it easier to run all "checks" through one task instead of having to remember all of them individually.