### PR TITLE
add bundle for default lint checks

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -29,6 +29,8 @@ default-testing = [ ... ]
 default-testing-compile = [ ... ]
 # any dependency in this bundle is automatically added to all modules as testRuntimeOnly dependency
 default-testing-runtime = [ ... ]
+# any dependency in this bundle is automatically added to all modules as lintChecks dependency
+default-lint = [ ... ]
 ```
 
 ### Kotlin

--- a/plugins/monoREADME.md
+++ b/plugins/monoREADME.md
@@ -97,6 +97,8 @@ default-testing = [ ... ]
 default-testing-compile = [ ... ]
 # any dependency in this bundle is automatically added to all modules as testRuntimeOnly dependency
 default-testing-runtime = [ ... ]
+# any dependency in this bundle is automatically added to all modules as lintChecks dependency
+default-lint = [ ... ]
 ```
 
 ## `app`

--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidLintSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidLintSetup.kt
@@ -1,6 +1,8 @@
 package com.freeletics.gradle.setup
 
 import com.android.build.api.dsl.Lint
+import com.freeletics.gradle.util.addMaybe
+import com.freeletics.gradle.util.getBundleOrNull
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFile
 import org.gradle.api.provider.Provider
@@ -26,6 +28,8 @@ internal fun Lint.configure(project: Project) {
     htmlOutput = project.reportsFile("lint-result.html").get().asFile
     textReport = true
     textOutput = project.reportsFile("lint-result.txt").get().asFile
+
+    project.dependencies.addMaybe("lintChecks", project.getBundleOrNull("default-lint"))
 }
 
 private fun Project.reportsFile(name: String): Provider<RegularFile> {


### PR DESCRIPTION
Similar to #189 this adds support to define a bundle for custom lint checks in the version catalog which will then be automatically added to all modules that use lint.