### PR TITLE
stop allowing legacy modules to depend on implementation modules

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyAndroidPlugin.kt
@@ -2,7 +2,6 @@ package com.freeletics.gradle.monorepo.plugin
 
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
-import com.freeletics.gradle.monorepo.util.projectType
 import com.freeletics.gradle.plugin.FreeleticsAndroidPlugin
 import com.freeletics.gradle.util.freeleticsAndroidExtension
 import org.gradle.api.Plugin
@@ -24,7 +23,7 @@ public abstract class LegacyAndroidPlugin : Plugin<Project> {
                 ProjectType.DOMAIN_TESTING,
                 ProjectType.FEATURE_NAV,
                 ProjectType.LEGACY,
-            )
+            ),
         )
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyAndroidPlugin.kt
@@ -21,18 +21,10 @@ public abstract class LegacyAndroidPlugin : Plugin<Project> {
                 ProjectType.CORE_API,
                 ProjectType.CORE_TESTING,
                 ProjectType.DOMAIN_API,
-                ProjectType.DOMAIN_IMPLEMENTATION,
                 ProjectType.DOMAIN_TESTING,
                 ProjectType.FEATURE_NAV,
                 ProjectType.LEGACY,
-            ) + if (target.projectType() == ProjectType.LEGACY_APP) {
-                listOf(
-                    ProjectType.CORE_IMPLEMENTATION,
-                    ProjectType.FEATURE_IMPLEMENTATION,
-                )
-            } else {
-                emptyList()
-            },
+            )
         )
     }
 }


### PR DESCRIPTION
We don't have these types of dependencies anymore so we can stop allowing it here to prevent them from being reintroduced.