### PR TITLE
disable tasks that we don't need to run

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppPlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableAndroidApplicationTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.monorepo.util.appType
@@ -122,5 +123,7 @@ public abstract class AppPlugin : Plugin<Project> {
                 ProjectType.LEGACY,
             ),
         )
+
+        target.disableAndroidApplicationTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/CoreAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/CoreAndroidPlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableAndroidLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.plugin.FreeleticsAndroidPlugin
@@ -24,5 +25,7 @@ public abstract class CoreAndroidPlugin : Plugin<Project> {
                 ProjectType.CORE_TESTING,
             ),
         )
+
+        target.disableAndroidLibraryTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/CoreKotlinPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/CoreKotlinPlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableKotlinLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.plugin.FreeleticsJvmPlugin
@@ -24,5 +25,7 @@ public abstract class CoreKotlinPlugin : Plugin<Project> {
                 ProjectType.CORE_TESTING,
             ),
         )
+
+        target.disableKotlinLibraryTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainAndroidPlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableAndroidLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.monorepo.util.appType
@@ -41,5 +42,7 @@ public abstract class DomainAndroidPlugin : Plugin<Project> {
                 ),
             )
         }
+
+        target.disableAndroidLibraryTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainKotlinPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainKotlinPlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableKotlinLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.plugin.FreeleticsJvmPlugin
@@ -37,5 +38,7 @@ public abstract class DomainKotlinPlugin : Plugin<Project> {
                 ),
             )
         }
+
+        target.disableKotlinLibraryTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeaturePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeaturePlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableAndroidLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.monorepo.util.appType
@@ -37,5 +38,7 @@ public abstract class FeaturePlugin : Plugin<Project> {
                 ),
             )
         }
+
+        target.disableAndroidLibraryTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyAndroidPlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableAndroidLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.plugin.FreeleticsAndroidPlugin
@@ -25,5 +26,7 @@ public abstract class LegacyAndroidPlugin : Plugin<Project> {
                 ProjectType.LEGACY,
             ),
         )
+
+        target.disableAndroidLibraryTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyKotlinPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyKotlinPlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableKotlinLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.plugin.FreeleticsJvmPlugin
@@ -25,5 +26,7 @@ public abstract class LegacyKotlinPlugin : Plugin<Project> {
                 ProjectType.LEGACY,
             ),
         )
+
+        target.disableKotlinLibraryTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/NavPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/NavPlugin.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.monorepo.plugin
 
+import com.freeletics.gradle.monorepo.setup.disableAndroidLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.monorepo.util.appType
@@ -24,5 +25,7 @@ public abstract class NavPlugin : Plugin<Project> {
                 ProjectType.DOMAIN_TESTING,
             ),
         )
+
+        target.disableAndroidLibraryTasks()
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/DisableTasks.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/DisableTasks.kt
@@ -1,0 +1,102 @@
+package com.freeletics.gradle.monorepo.setup
+
+import com.android.build.api.variant.AndroidComponentsExtension
+import com.freeletics.gradle.monorepo.util.capitalize
+import org.gradle.api.Project
+
+internal fun Project.disableAndroidApplicationTasks() {
+    disableAndroidTasks(androidAppLintTasksToDisableExceptOneVariant, "debug")
+}
+
+internal fun Project.disableAndroidLibraryTasks() {
+    disableAndroidTasks(androidLibraryTasksToDisable)
+    disableAndroidTasks(androidLibraryLintTasksToDisable)
+    disableAndroidTasks(androidLibraryLintTasksToDisableExceptOneVariant, "debug")
+}
+
+internal fun Project.disableKotlinLibraryTasks() {
+    disableTasks(listOf("assemble"))
+    disableTasks(lintTasksToDisableJvm)
+}
+
+private fun Project.disableAndroidTasks(names: List<String>, variantToKeep: String = "") {
+    extensions.configure<AndroidComponentsExtension<*, *, *>>("androidComponents") { components ->
+        components.onVariants { variant ->
+            if (variant.name != variantToKeep) {
+                val variantAwareNames = names.map { it.replace("{VARIANT}", variant.name.capitalize()) }
+                disableTasks(variantAwareNames)
+            }
+        }
+    }
+}
+
+private fun Project.disableTasks(names: List<String>) {
+    afterEvaluate {
+        names.forEach { name ->
+            tasks.named(name).configure {
+                it.enabled = false
+                it.description = "DISABLED"
+                it.setDependsOn(mutableListOf<Any>())
+            }
+        }
+    }
+}
+
+// disable these tasks since we never want to build an aar out of
+// library modules and AGP consumes the individual elements directly
+private val androidLibraryTasksToDisable = listOf(
+    "assemble",
+    "assemble{VARIANT}",
+    "bundle{VARIANT}Aar",
+)
+
+// for libraries remove all reporting tasks so that they only
+// have the analyze task since we have an aggregated report at
+// the app level
+private val androidLibraryLintTasksToDisable = listOf(
+    // report
+    "lint",
+    "lint{VARIANT}",
+    "lintReport{VARIANT}",
+    "copy{VARIANT}AndroidLintReports",
+    // fix
+    "lintFix",
+    "lintFix{VARIANT}",
+    // baseline
+    "updateLintBaseline",
+    "updateLintBaseline{VARIANT}",
+)
+
+// disable debug variant of these tasks, we're only running on release
+private val androidLibraryLintTasksToDisableExceptOneVariant = listOf(
+    // analyze
+    "lintAnalyze{VARIANT}",
+)
+
+// disable debug variant of these tasks, we're only running on release
+private val androidAppLintTasksToDisableExceptOneVariant = listOf(
+    // analyze
+    "lintAnalyze{VARIANT}",
+    // report
+    "lint{VARIANT}",
+    "lintReport{VARIANT}",
+    "copy{VARIANT}AndroidLintReports",
+    // fix
+    "lintFix{VARIANT}",
+    // baseline
+    "updateLintBaseline{VARIANT}",
+)
+
+// same as the Android library tasks, only keep analyze and the report
+// is created in the app module
+private val lintTasksToDisableJvm = listOf(
+    "lint",
+    "lintReport",
+    "copyAndroidLintReports",
+    "lintFix",
+    "updateLintBaseline",
+    // TODO these shouldn't be created by AGP in the first place
+    "lintVital",
+    "lintVitalAnalyze",
+    "lintVitalReport",
+)


### PR DESCRIPTION
Disables some tasks (especially lint tasks) so that we can run `.gradlew lint`, `./gradlew assemble`, `./gradlew check` and `./gradlew build` locally without building/analyzing way too much. The `build` now matches the tasks that we execute on ci.