### PR TITLE
always enable Room Kotlin codegen

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -5,7 +5,6 @@ import com.freeletics.gradle.setup.configurePaparazzi
 import com.freeletics.gradle.setup.configureProcessing
 import com.freeletics.gradle.util.android
 import com.freeletics.gradle.util.androidResources
-import com.freeletics.gradle.util.booleanProperty
 import com.freeletics.gradle.util.getDependency
 import org.gradle.api.Project
 

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -12,10 +12,9 @@ import org.gradle.api.Project
 public abstract class FreeleticsAndroidExtension(private val project: Project) {
 
     public fun useRoom() {
-        val generateKotlin = project.booleanProperty("fgp.room.generateKotlin", true).get()
         val processorConfiguration = project.configureProcessing(
             useKsp = true,
-            "room.generateKotlin" to generateKotlin.toString(),
+            "room.generateKotlin" to "true",
         )
 
         project.dependencies.apply {


### PR DESCRIPTION
Since Room 2.6.0 is out we can always enable the Room Kotlin codegen and remove the Gradle property.