### PR TITLE
adjust version code logic from v24 on

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersion.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersion.kt
@@ -2,6 +2,7 @@ package com.freeletics.gradle.monorepo.tasks
 
 import com.freeletics.gradle.monorepo.util.Git
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 /**
  * Get the app version name, which is computed using the branch name or `git describe`.
@@ -15,7 +16,7 @@ public fun computeVersionName(git: Git, gitTagName: String): String {
 /**
  * Get the app version name, which is computed using the branch name or `git describe`.
  */
-public fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDate): Int {
+public fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDateTime): Int {
     val major: Int
     val minor: Int
     val patch: Int
@@ -24,6 +25,15 @@ public fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDate
     val version = versionFromTag(git, gitTagName, exactMatch = true)
     if (version != null) {
         // if we are building a tagged commit use the version to compute the version code
+        //
+        // New (since major v24):
+        //
+        // 2_100_000_000 - maximum allowed value
+        //    24_xxx_xxx - major version 24
+        //    xx_x31_xxx - minor version 31
+        //    xx_xxx_x00 - patch version 0
+        //
+        // Old (until major v24):
         //
         // 2_100_000_000 - maximum allowed value
         //    22_xxx_xxx - major version 22
@@ -42,11 +52,28 @@ public fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDate
             "Version code can only be computed on the main branch and tagged commits"
         }
 
-        // Untagged builds will use the last version for the computed build number.
-        // Patch is always 0 in this case however it will set the digit for thousands at least to 1 (this digit
-        // is unused by regular releases). This guarantees that a nighly build will always have a higher build number
-        // than last week's release (including hotfixes) but one that is lower than then the release created at the
-        // end of the week, which should be the safest behavior in regard to build number based fencing.
+        // Untagged builds will use the major and minor version of the last version for
+        // the computed build number.
+        //
+        // New (since major v24):
+        //
+        // We use the day of week in the 100 digit to get a higher build number than
+        // anything the last release can reach. The last 2 digits are used for the time
+        // of day to generally have the ability to produce multiple builds per day
+        // for testing (in practice we get a new build number every 15 minutes which is
+        // good enough for one-off manual tests).
+        //
+        // 2_100_000_000 - maximum allowed value
+        //    24_xxx_xxx - major version 24
+        //    xx_x31_xxx - minor version 31
+        //    xx_xxx_1xx - day of week
+        //    xx_xxx_x99 - time of day in 15 minute intervals
+        //
+        // Old (until major v24):
+        //
+        // We use the day of week in the 100 digit to get a higher build number than
+        // anything the last release can reach. The last 3 digits are used for the
+        // number of commits since the last release.
         //
         // 2_100_000_000 - maximum allowed value
         //    22_xxx_xxx - major version 22
@@ -65,19 +92,33 @@ public fun computeVersionCode(git: Git, gitTagName: String, localDate: LocalDate
         patch = 0
         checkVersions(major, minor, patch)
 
-        // Monday = 1000, Sunday = 7000
-        val dayOfWeek = localDate.dayOfWeek.value * 1_000
-        // the returned version has 7.4.0-32-g5e2416d73f as format where the 32 is the commit count since the tag
-        val commitsSinceLastRelease = suffixParts[1].toInt()
-        check(commitsSinceLastRelease < 1_000) { "More than 999 commits found since the last release was created" }
-
-        extra = dayOfWeek + commitsSinceLastRelease
+        extra = if (major >= 24) {
+            // Monday = 100, Sunday = 700
+            val dayOfWeek = localDate.dayOfWeek.value * 100
+            // Time of day in 15 minute intervals -> values from 0 to 96
+            val time = (localDate.hour * 60 + localDate.minute) / 15
+            dayOfWeek + time
+        } else {
+            // Monday = 1000, Sunday = 7000
+            val dayOfWeek = localDate.dayOfWeek.value * 1_000
+            // the returned version has 7.4.0-32-g5e2416d73f as format where the 32 is the commit count since the tag
+            val commitsSinceLastRelease = suffixParts[1].toInt()
+            check(commitsSinceLastRelease < 1_000) { "More than 999 commits found since the last release was created" }
+            dayOfWeek + commitsSinceLastRelease
+        }
     }
 
-    val versionCode = major * 1_000_000 +
-        minor * 10_000 +
-        patch +
-        extra
+    val versionCode = if (major >= 24) {
+        major * 1_000_000 +
+            minor * 1_000 +
+            patch +
+            extra
+    } else {
+        major * 1_000_000 +
+            minor * 10_000 +
+            patch +
+            extra
+    }
     check(versionCode < 1_000_000_000) { "Version code should always be lower than 1 billion, was $versionCode" }
 
     return versionCode
@@ -89,7 +130,7 @@ private fun checkVersions(major: Int, minor: Int, patch: Int) {
     // minor is limited to the number of weeks in a year, so 52 or 53 in practice
     check(minor < 100) { "Minor version is limited to 99, was $minor" }
     // patch is limited to three digits
-    check(patch < 1000) { "Patch is limited to 999, was $patch" }
+    check(patch < 100) { "Patch is limited to 99, was $patch" }
 }
 
 /**

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersion.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersion.kt
@@ -1,7 +1,6 @@
 package com.freeletics.gradle.monorepo.tasks
 
 import com.freeletics.gradle.monorepo.util.Git
-import java.time.LocalDate
 import java.time.LocalDateTime
 
 /**

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionCodeTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionCodeTask.kt
@@ -3,7 +3,6 @@ package com.freeletics.gradle.monorepo.tasks
 import com.freeletics.gradle.monorepo.util.RealGit
 import com.freeletics.gradle.monorepo.util.computeInfoFromGit
 import java.io.File
-import java.time.LocalDate
 import java.time.LocalDateTime
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionCodeTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionCodeTask.kt
@@ -4,6 +4,7 @@ import com.freeletics.gradle.monorepo.util.RealGit
 import com.freeletics.gradle.monorepo.util.computeInfoFromGit
 import java.io.File
 import java.time.LocalDate
+import java.time.LocalDateTime
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
@@ -32,7 +33,7 @@ public abstract class ComputeVersionCodeTask : DefaultTask() {
     public fun action() {
         val versionCode = if (computeFromGit.get()) {
             val git = RealGit(gitRootDirectory.get())
-            computeVersionCode(git, gitTagName.get(), LocalDate.now())
+            computeVersionCode(git, gitTagName.get(), LocalDateTime.now())
         } else {
             Int.MAX_VALUE
         }

--- a/plugins/src/test/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionCodeTest.kt
+++ b/plugins/src/test/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionCodeTest.kt
@@ -109,6 +109,7 @@ internal class ComputeVersionCodeTest {
 
         assertThat(computeVersionCode(git, "fl", date)).isEqualTo(24044500)
     }
+
     @Test
     fun `v24+, when there is no tag it returns version computed from last tag and current day - friday evening`() {
         val date = LocalDate.of(2022, 11, 11).atTime(19, 35) // friday


### PR DESCRIPTION
From version 24.1.0 on (next year) the version code will move the part for the minor version one digit to the right. This leaves an unused `0` between the minor version and the major version and is purely for readability purposes.

Examples:
- 24.1.0: `24010000` -> `24001000`
- 24.10.0: `24100000` -> `24010000`
- 24.24.0: `24240000` -> `24024000`
- 24.44.0: `24440000` -> `24044000`

For regular release builds the last 2 digits are used for patches (both beta patches and hotfix) and the 100 digit is unused.

The logic for untagged builds which we use for nightly builds is adjusted to use the last 3 digits. The first of those 3 is still used for the day of week. Since that leaves only 2 digits and 99 commits per release/week is not enough we now use the time of day there. This allows to still do multiple "nightly" builds per day for testing purposes. The only limitation is that you can only do one every 15 minutes but that is fine for one-off tests.