### PR TITLE
enable compose by default in feature modules

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeaturePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeaturePlugin.kt
@@ -17,6 +17,7 @@ public abstract class FeaturePlugin : Plugin<Project> {
 
         val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
 
+        target.freeleticsExtension.useCompose()
         target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
         target.freeleticsAndroidExtension.enableAndroidResources()
         target.freeleticsAndroidExtension.enableParcelize()


### PR DESCRIPTION
We have compose in all our feature modules now so we can just enable it by default.