### PR TITLE
adapt publishing for xcframework uploads

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishInternalPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsPublishInternalPlugin.kt
@@ -26,7 +26,10 @@ public abstract class FreeleticsPublishInternalPlugin : Plugin<Project> {
                     repositories.maven {
                         it.name = "internalArtifacts"
                         it.setUrl(internalUrl)
-                        it.credentials(PasswordCredentials::class.java)
+                        // allows using the internal url property to specify a local folder for testing
+                        if (!internalUrl.startsWith("file:")) {
+                            it.credentials(PasswordCredentials::class.java)
+                        }
                     }
                 }
             }
@@ -34,15 +37,9 @@ public abstract class FreeleticsPublishInternalPlugin : Plugin<Project> {
     }
 
     private fun Project.disablePublishingIosArtifacts() {
-        extensions.configure(PublishingExtension::class.java) { publishing ->
-            publishing.publications.configureEach { publication ->
-                if (publication.name.contains("ios", ignoreCase = true)) {
-                    tasks.withType(AbstractPublishToMaven::class.java).configureEach {
-                        if (it.publication == publication) {
-                            it.onlyIf { false }
-                        }
-                    }
-                }
+        tasks.withType(AbstractPublishToMaven::class.java).configureEach {
+            if (it.name.contains("ios", ignoreCase = true)) {
+                it.onlyIf { false }
             }
         }
     }


### PR DESCRIPTION
When the iOS targets are added, creating an xcframework is enabled and our internal publishing plugin is applied, we are now automatically adding a task to zip the xcframework and add the zip to a publication. This makes the set up we already have in one internal project reusable.

Another small change is to allow setting `fgp.internalArtifacts.url` to a `file://` uri for testing. The only change needed for this was to not add the password credentials in that case.