### PR TITLE
update default dependency analysis excludes

### DIFF
--- a/plugin-root/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
+++ b/plugin-root/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
@@ -101,6 +101,7 @@ public abstract class RootPlugin : Plugin<Project> {
 
                     project.onUnusedDependencies {
                         it.exclude(
+                            "() -> kotlin.Any?",
                             // added by the Kotlin plugin
                             "org.jetbrains.kotlin:kotlin-stdlib",
                             // parcelize is enabled on all Android modules
@@ -118,6 +119,8 @@ public abstract class RootPlugin : Plugin<Project> {
 
                     project.onIncorrectConfiguration {
                         it.exclude(
+                            // added by the Kotlin plugin
+                            "org.jetbrains.kotlin:kotlin-stdlib",
                             // Dagger is always added as "api", but some modules only use it in for example debugApi
                             "javax.inject:javax.inject",
                             "com.squareup.anvil:annotations",


### PR DESCRIPTION
- `org.jetbrains.kotlin:kotlin-stdlib` is added by KGP so we don't control which configuration it's added to 
- in some projects we get a weird `() -> kotlin.Any?` dependency reported as unused, ignoring that since it's not actioable