### PR TITLE
remove AGP 8.2.0 flags

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppPlugin.kt
@@ -1,6 +1,5 @@
 package com.freeletics.gradle.monorepo.plugin
 
-import com.android.build.api.AndroidPluginVersion
 import com.freeletics.gradle.monorepo.setup.applyPlatformConstraints
 import com.freeletics.gradle.monorepo.setup.disableAndroidApplicationTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
@@ -9,7 +8,6 @@ import com.freeletics.gradle.monorepo.util.appType
 import com.freeletics.gradle.plugin.FreeleticsAndroidAppPlugin
 import com.freeletics.gradle.util.androidApp
 import com.freeletics.gradle.util.androidComponents
-import com.freeletics.gradle.util.androidPluginVersion
 import com.freeletics.gradle.util.freeleticsAndroidExtension
 import com.freeletics.gradle.util.freeleticsExtension
 import com.freeletics.gradle.util.stringProperty
@@ -54,7 +52,7 @@ public abstract class AppPlugin : Plugin<Project> {
 
             androidResources {
                 @Suppress("UnstableApiUsage")
-                generateLocaleConfig = androidPluginVersion >= AndroidPluginVersion(8, 2, 0)
+                generateLocaleConfig = true
             }
 
             buildTypes {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/DisableTasks.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/DisableTasks.kt
@@ -60,16 +60,12 @@ private val androidLibraryTasksToDisable = listOf(
 // for libraries remove all reporting tasks so that they only
 // have the analyze task since we have an aggregated report at
 // the app level
-private val Project.androidLibraryLintTasksToDisable get() = listOf(
+private val androidLibraryLintTasksToDisable get() = listOf(
     // report
     "lint",
     "lint{VARIANT}",
     "lintReport{VARIANT}",
-    if (androidPluginVersion >= AndroidPluginVersion(8, 2, 0)) {
-        "copy{VARIANT}LintReports"
-    } else {
-        "copy{VARIANT}AndroidLintReports"
-    },
+    "copy{VARIANT}LintReports",
     // fix
     "lintFix",
     "lintFix{VARIANT}",
@@ -91,11 +87,7 @@ private val androidAppLintTasksToDisableExceptOneVariant get() = listOf(
     // report
     "lint{VARIANT}",
     "lintReport{VARIANT}",
-    if (androidPluginVersion >= AndroidPluginVersion(8, 2, 0)) {
-        "copy{VARIANT}LintReports"
-    } else {
-        "copy{VARIANT}AndroidLintReports"
-    },
+    "copy{VARIANT}LintReports",
     // fix
     "lintFix{VARIANT}",
     // baseline
@@ -105,34 +97,21 @@ private val androidAppLintTasksToDisableExceptOneVariant get() = listOf(
 // same as the Android library tasks, only keep analyze and the report
 // is created in the app module
 private val lintTasksToDisableJvm
-    get() = if (androidPluginVersion >= AndroidPluginVersion(8, 2, 0)) {
-        listOf(
-            "lint",
-            "lintJvm",
-            "lintReportJvm",
-            "copyJvmLintReports",
-            "lintFix",
-            "lintFixJvm",
-            "updateLintBaseline",
-            "updateLintBaselineJvm",
-            "lintVital",
-            "lintVitalJvm",
-            if (androidPluginVersion >= AndroidPluginVersion(8, 3, 0)) {
-                "lintVitalAnalyzeJvmMain"
-            } else {
-                "lintVitalAnalyzeJvm"
-            },
-            "lintVitalReportJvm",
-        )
-    } else {
-        listOf(
-            "lint",
-            "lintReport",
-            "copyAndroidLintReports",
-            "lintFix",
-            "updateLintBaseline",
-            "lintVital",
-            "lintVitalAnalyze",
-            "lintVitalReport",
-        )
-    }
+    get() = listOf(
+        "lint",
+        "lintJvm",
+        "lintReportJvm",
+        "copyJvmLintReports",
+        "lintFix",
+        "lintFixJvm",
+        "updateLintBaseline",
+        "updateLintBaselineJvm",
+        "lintVital",
+        "lintVitalJvm",
+        if (androidPluginVersion >= AndroidPluginVersion(8, 3, 0)) {
+            "lintVitalAnalyzeJvmMain"
+        } else {
+            "lintVitalAnalyzeJvm"
+        },
+        "lintVitalReportJvm",
+    )


### PR DESCRIPTION
Since it was released faster than this plugin we don't need the version check anymore.