### PR TITLE
remove iosX64 from iOS only targets

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -60,15 +60,6 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
                 configure()
             }
 
-            iosX64 {
-                binaries.framework {
-                    baseName = frameworkName
-                    xcFramework?.add(this)
-                }
-
-                configure()
-            }
-
             iosSimulatorArm64 {
                 binaries.framework {
                     baseName = frameworkName
@@ -99,7 +90,7 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
 
                 val publicationName = "${frameworkName}XcFramework"
                 project.extensions.configure(PublishingExtension::class.java) { publishing ->
-                    publishing.publications.create("${frameworkName}XcFramework", MavenPublication::class.java) {
+                    publishing.publications.create(publicationName, MavenPublication::class.java) {
                         // the project.name will be replaced with the real artifact id by the publishing plugin
                         it.artifactId = "${project.name}-xcframework"
                         it.artifact(frameworkZip) { artifact ->
@@ -111,10 +102,6 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
                 project.tasks.withType(AbstractPublishToMaven::class.java).configureEach {
                     if (it.name.contains(publicationName, ignoreCase = true)) {
                         it.onlyIf { HostManager.hostIsMac }
-                    } else {
-                        // for now we accept that a module that publishes an xcframework
-                        // will not publish anything else
-                        it.onlyIf { false }
                     }
                 }
             }


### PR DESCRIPTION
We don't include this anymore for libraries just targeting iOS. Also removed the logic to always disable the iOS publications since we have more granular logic for that internally.