### PR TITLE
add mechanism to override version catalog versions

### DIFF
--- a/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
+++ b/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
@@ -104,6 +104,15 @@ public abstract class SettingsPlugin : Plugin<Settings> {
                 @Suppress("UnstableApiUsage")
                 management.repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
             }
+
+            val prefix = "fgp.version.override."
+            management.versionCatalogs {
+                val libs = it.maybeCreate("libs")
+                @Suppress("UnstableApiUsage")
+                target.providers.gradlePropertiesPrefixedBy(prefix).get().forEach { (name, version) ->
+                    libs.version(name.substringAfter(prefix), version)
+                }
+            }
         }
 
         target.buildCache {


### PR DESCRIPTION
Allows specifying a property like `fgp.version.override.anvil` to change the Anvil version for current build. Makes testing different versions easier.