### PR TITLE
set -Xjdk-release Kotlin compiler option

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -1,10 +1,12 @@
 package com.freeletics.gradle.plugin
 
+import com.freeletics.gradle.util.KotlinAndroidProjectExtensionDelegate
 import com.freeletics.gradle.util.addMaybe
 import com.freeletics.gradle.util.booleanProperty
 import com.freeletics.gradle.util.getBundleOrNull
 import com.freeletics.gradle.util.getVersionOrNull
 import com.freeletics.gradle.util.java
+import com.freeletics.gradle.util.javaTarget
 import com.freeletics.gradle.util.javaToolchainVersion
 import com.freeletics.gradle.util.jvmTarget
 import com.freeletics.gradle.util.kotlin
@@ -64,6 +66,8 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                 toolchain.vendor.set(JvmVendorSpec.AZUL)
             }
 
+            val isAndroid = this is KotlinAndroidProjectExtensionDelegate
+
             compilerOptions {
                 getVersionOrNull("kotlin-language")?.let {
                     languageVersion.set(KotlinVersion.fromVersion(it))
@@ -93,6 +97,10 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                         // Enhance not null annotated type parameter's types to definitely not null types (@NotNull T => T & Any)
                         "-Xenhance-type-parameter-types-to-def-not-null",
                     )
+
+                    if (!isAndroid) {
+                        freeCompilerArgs.add("-Xjdk-release=${project.javaTarget}")
+                    }
 
                     if (project.booleanProperty("fgp.kotlin.fastJarFs", false).get()) {
                         freeCompilerArgs.add("-Xuse-fast-jar-file-system")

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
@@ -4,6 +4,7 @@ import com.freeletics.gradle.setup.defaultTestSetup
 import com.freeletics.gradle.util.freeleticsExtension
 import com.freeletics.gradle.util.java
 import com.freeletics.gradle.util.javaTargetVersion
+import com.freeletics.gradle.util.kotlin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.JavaCompile

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsJvmPlugin.kt
@@ -4,7 +4,6 @@ import com.freeletics.gradle.setup.defaultTestSetup
 import com.freeletics.gradle.util.freeleticsExtension
 import com.freeletics.gradle.util.java
 import com.freeletics.gradle.util.javaTargetVersion
-import com.freeletics.gradle.util.kotlin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.JavaCompile

--- a/plugins/src/main/kotlin/com/freeletics/gradle/util/VersionCatalog.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/util/VersionCatalog.kt
@@ -40,11 +40,14 @@ internal fun DependencyHandler.addMaybe(name: String, dependency: Any?) {
     }
 }
 
+internal val Project.javaTarget: String
+    get() = getVersion("java-target")
+
 internal val Project.javaTargetVersion: JavaVersion
-    get() = JavaVersion.toVersion(getVersion("java-target"))
+    get() = JavaVersion.toVersion(javaTarget)
 
 internal val Project.jvmTarget: JvmTarget
-    get() = JvmTarget.fromTarget(getVersion("java-target"))
+    get() = JvmTarget.fromTarget(javaTarget)
 
 internal val Project.javaToolchainVersion: JavaLanguageVersion
     get() = JavaLanguageVersion.of(getVersion("java-toolchain"))


### PR DESCRIPTION
Avoids accidentally accessing features/APIs from Java versions that are newer than the targeted one. For more see https://jakewharton.com/kotlins-jdk-release-compatibility-flag/