### PR TITLE
add test target to wasmJs

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -112,12 +112,14 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
         project.kotlinMultiplatform {
             jvm()
 
-            js(KotlinJsCompilerType.IR) {
+            js {
                 nodejs()
             }
 
             @OptIn(ExperimentalWasmDsl::class)
-            wasmJs()
+            wasmJs {
+                nodejs()
+            }
 
             linuxX64()
             linuxArm64()


### PR DESCRIPTION
Avoids a warning like this
```
w: Please choose a JavaScript environment to build distributions and run tests.
Not choosing any of them will be an error in the future releases.
kotlin {
    js {
        // To build distributions for and run tests on browser or Node.js use one or both of:
        browser()
        nodejs()
        d8
    }
}
```