### PR TITLE
remove LegacyExtension from domain-android plugin

### DIFF
--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -99,10 +99,5 @@ gradlePlugin {
             id = "com.freeletics.gradle.legacy.android"
             implementationClass = "com.freeletics.gradle.monorepo.plugin.LegacyAndroidPlugin"
         }
-
-        create("monoLegacyKotlinPlugin") {
-            id = "com.freeletics.gradle.legacy.kotlin"
-            implementationClass = "com.freeletics.gradle.monorepo.plugin.LegacyKotlinPlugin"
-        }
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainAndroidPlugin.kt
@@ -16,33 +16,23 @@ public abstract class DomainAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsAndroidPlugin::class.java)
 
-        val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
-
         target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
         target.freeleticsAndroidExtension.enableParcelize()
 
-        target.afterEvaluate {
-            target.registerCheckDependencyRulesTasks(
-                allowedProjectTypes = listOf(
-                    ProjectType.DOMAIN_API,
-                    ProjectType.DOMAIN_IMPLEMENTATION,
-                    ProjectType.DOMAIN_TESTING,
-                ),
-                allowedDependencyProjectTypes = listOfNotNull(
-                    ProjectType.CORE_API,
-                    ProjectType.CORE_TESTING,
-                    ProjectType.DOMAIN_API,
-                    ProjectType.DOMAIN_TESTING,
-                    if (target.projectType() == ProjectType.DOMAIN_IMPLEMENTATION) ProjectType.FEATURE_NAV else null,
-                    // TODO remove after migrating domain modules away from legacy
-                    if (extension.allowLegacyDependencies) {
-                        ProjectType.LEGACY
-                    } else {
-                        null
-                    },
-                ),
-            )
-        }
+        target.registerCheckDependencyRulesTasks(
+            allowedProjectTypes = listOf(
+                ProjectType.DOMAIN_API,
+                ProjectType.DOMAIN_IMPLEMENTATION,
+                ProjectType.DOMAIN_TESTING,
+            ),
+            allowedDependencyProjectTypes = listOfNotNull(
+                ProjectType.CORE_API,
+                ProjectType.CORE_TESTING,
+                ProjectType.DOMAIN_API,
+                ProjectType.DOMAIN_TESTING,
+                if (target.projectType() == ProjectType.DOMAIN_IMPLEMENTATION) ProjectType.FEATURE_NAV else null,
+            ),
+        )
 
         target.applyPlatformConstraints()
         target.disableAndroidLibraryTasks()


### PR DESCRIPTION
We don't have anymore domain modules depending on legacy modules, so we can remove the opt-in.