### PR TITLE
add useSerialization for kotlinx.serialization

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -32,6 +32,10 @@ public abstract class FreeleticsBaseExtension(private val project: Project) : Ex
         project.configureMoshi(sealed)
     }
 
+    public fun useSerialization() {
+        project.plugins.apply("org.jetbrains.kotlin.plugin.serialization")
+    }
+
     public fun useDagger() {
         project.configureDagger(DaggerMode.ANVIL_ONLY)
     }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -3,6 +3,7 @@ package com.freeletics.gradle.plugin
 import com.freeletics.gradle.setup.configureDagger
 import com.freeletics.gradle.setup.configureMoshi
 import com.freeletics.gradle.setup.setupCompose
+import com.freeletics.gradle.util.getDependency
 import com.freeletics.gradle.util.kotlin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
@@ -34,6 +35,8 @@ public abstract class FreeleticsBaseExtension(private val project: Project) : Ex
 
     public fun useSerialization() {
         project.plugins.apply("org.jetbrains.kotlin.plugin.serialization")
+
+        project.dependencies.add("api", project.getDependency("kotlinx-serialization"))
     }
 
     public fun useDagger() {


### PR DESCRIPTION
Adds a DSL method to enable `kotlinx.serialization` which currently only consists of applying the plugin. We're already using this in khonshu and I'm exploring using it more generally.