### PR TITLE
split anvil ksp for app modules

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/DaggerAnvilSetup.kt
@@ -10,10 +10,13 @@ import com.squareup.anvil.plugin.AnvilExtension
 import org.gradle.api.Project
 
 internal fun Project.configureDagger(mode: DaggerMode) {
-    val anvilKsp = booleanProperty("fgp.kotlin.anvilKsp", false)
-    val daggerKsp = booleanProperty("fgp.kotlin.daggerKsp", false)
-
     val runDagger = mode == ANVIL_WITH_FULL_DAGGER
+    val anvilKsp = if (runDagger) {
+        booleanProperty("fgp.kotlin.anvilKspWithComponent", false)
+    } else {
+        booleanProperty("fgp.kotlin.anvilKsp", false)
+    }
+    val daggerKsp = booleanProperty("fgp.kotlin.daggerKsp", false)
     val runDaggerInKsp = runDagger && daggerKsp.get()
 
     plugins.apply("com.squareup.anvil")
@@ -27,6 +30,7 @@ internal fun Project.configureDagger(mode: DaggerMode) {
         }
         it.generateDaggerFactories.set(!runDagger)
         it.disableComponentMerging.set(!runDagger)
+        it.trackSourceFiles.set(true)
     }
 
     dependencies.apply {


### PR DESCRIPTION
For now we need to be able to turn Anvil KSP on separately based on whether the module has `@Component`/`@MergeComponent` declarations in it or not (so based on whether a modules has `useDaggerWithComponent`). This is because when enabling Anvil KSP the code generation for contributed subcomponents is not running before component merging. Having this will allow turning on Anvil KSP for most of the app and keep it off for the rest.

Also hardcodes `trackSourceFiles` to true. The incremental compilation fixes have been working well so far, so we can enable them by default.