### PR TITLE
only enable Kotlin progressive mode for current or newer language levels

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -69,14 +69,13 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
             val isAndroid = this is KotlinAndroidProjectExtensionDelegate
 
             compilerOptions {
-                getVersionOrNull("kotlin-language")?.let {
-                    languageVersion.set(KotlinVersion.fromVersion(it))
-                }
+                val languageVersion = getVersionOrNull("kotlin-language")?.let(KotlinVersion::fromVersion) ?: KotlinVersion.DEFAULT
+                this.languageVersion.set(languageVersion)
 
                 allWarningsAsErrors.set(!booleanProperty("fgp.kotlin.allowWarnings", false).get())
 
                 // In this mode, some deprecations and bug-fixes for unstable code take effect immediately.
-                progressiveMode.set(true)
+                progressiveMode.set(languageVersion >= KotlinVersion.DEFAULT)
 
                 // Support inferring type arguments based on only self upper bounds of the corresponding type parameters
                 // https://kotlinlang.org/docs/whatsnew1530.html#improvements-to-type-inference-for-recursive-generic-types

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -69,13 +69,14 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
             val isAndroid = this is KotlinAndroidProjectExtensionDelegate
 
             compilerOptions {
-                val languageVersion = getVersionOrNull("kotlin-language")?.let(KotlinVersion::fromVersion) ?: KotlinVersion.DEFAULT
-                this.languageVersion.set(languageVersion)
+                val version = getVersionOrNull("kotlin-language")
+                    ?.let(KotlinVersion::fromVersion) ?: KotlinVersion.DEFAULT
+                languageVersion.set(version)
 
                 allWarningsAsErrors.set(!booleanProperty("fgp.kotlin.allowWarnings", false).get())
 
                 // In this mode, some deprecations and bug-fixes for unstable code take effect immediately.
-                progressiveMode.set(languageVersion >= KotlinVersion.DEFAULT)
+                progressiveMode.set(version >= KotlinVersion.DEFAULT)
 
                 // Support inferring type arguments based on only self upper bounds of the corresponding type parameters
                 // https://kotlinlang.org/docs/whatsnew1530.html#improvements-to-type-inference-for-recursive-generic-types


### PR DESCRIPTION
Resolves getting warnings for progressive mode not doing anything when forcing the language version to an older one (e.g. when setting it to `1.9` in Kotlin 2.0 to use K1).