### PR TITLE
don't publish build scan by default

### DIFF
--- a/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
+++ b/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
@@ -23,6 +23,11 @@ public abstract class SettingsPlugin : Plugin<Settings> {
             it.buildScan { scan ->
                 scan.termsOfUseUrl.set("https://gradle.com/terms-of-service")
                 scan.termsOfUseAgree.set("yes")
+                scan.capture {
+                    it.buildLogging.set(false)
+                    it.testLogging.set(false)
+                }
+                scan.publishing.onlyIf { false }
             }
         }
 


### PR DESCRIPTION
Brings it back to the behavior before 3.17