### PR TITLE
add workaround for js repositories being added by project

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
@@ -28,5 +28,21 @@ public abstract class FreeleticsMultiplatformPlugin : Plugin<Project> {
         }
 
         target.tasks.withType(Test::class.java).configureEach(Test::defaultTestSetup)
+
+        target.rootProject.disableDefaultJsRepositories()
+    }
+
+    // TODO remove after https://youtrack.jetbrains.com/issue/KT-68533
+    private fun Project.disableDefaultJsRepositories() {
+        plugins.withType(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin::class.java) {
+            extensions.configure(org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension::class.java) {
+                it.downloadBaseUrl = null
+            }
+        }
+        plugins.withType(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin::class.java) {
+            extensions.configure(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension::class.java) {
+                it.downloadBaseUrl = null
+            }
+        }
     }
 }


### PR DESCRIPTION
- Adds back `management.repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)`, I accidentally removed it in the K2 update (#341). The intention was just to make it unconditional with no way to opt-out.
- Adds a workaround for the Kotlin Multiplatform plugin adding repositories when using JS ([KT-68533](https://youtrack.jetbrains.com/issue/KT-68533)). We are adding the repositories ourselves in the settings plugin so that they exist and don't need to be added by a `Project` which would cause the repository mode above to fail. From the multiplatform plugin which is the only place where we would have js targets we then set the `downloadBaseUrl` to `null` to prevent Kotlin from adding those repos.