### PR TITLE
set buildFeatures.compose = true for Android project to fix previews

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/ComposeSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/ComposeSetup.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.setup
 
+import com.android.build.api.dsl.LibraryExtension
 import com.freeletics.gradle.util.booleanProperty
 import com.freeletics.gradle.util.compilerOptions
 import com.freeletics.gradle.util.kotlin
@@ -7,6 +8,11 @@ import org.gradle.api.Project
 
 internal fun Project.setupCompose() {
     plugins.apply("org.jetbrains.kotlin.plugin.compose")
+
+    // TODO remove after https://issuetracker.google.com/issues/341986306
+    plugins.withId("com.android.library") {
+        extensions.getByType(LibraryExtension::class.java).buildFeatures.compose = true
+    }
 
     val enableMetrics = project.booleanProperty("fgp.compose.enableCompilerMetrics", false)
     if (enableMetrics.get()) {


### PR DESCRIPTION
Android Studio seems to be relying on this for previews to work.