### PR TITLE
make useDagger usable in multiplatform projects

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -3,6 +3,7 @@ package com.freeletics.gradle.plugin
 import com.freeletics.gradle.setup.configureDagger
 import com.freeletics.gradle.setup.configureMoshi
 import com.freeletics.gradle.setup.setupCompose
+import com.freeletics.gradle.util.addApiDependency
 import com.freeletics.gradle.util.compilerOptions
 import com.freeletics.gradle.util.getDependency
 import com.freeletics.gradle.util.kotlin
@@ -37,7 +38,7 @@ public abstract class FreeleticsBaseExtension(private val project: Project) : Ex
     public fun useSerialization() {
         project.plugins.apply("org.jetbrains.kotlin.plugin.serialization")
 
-        project.dependencies.add("api", project.getDependency("kotlinx-serialization"))
+        project.addApiDependency(project.getDependency("kotlinx-serialization"))
     }
 
     public fun useDagger() {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/util/Kmp.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/util/Kmp.kt
@@ -1,0 +1,77 @@
+package com.freeletics.gradle.util
+
+import com.freeletics.gradle.monorepo.util.capitalize
+import org.gradle.api.Project
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.provider.Provider
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
+
+internal fun Project.addApiDependency(
+    dependency: Provider<MinimalExternalModuleDependency>?,
+    limitToTargets: Set<KotlinPlatformType>? = null,
+) {
+    addDependency(
+        dependency = dependency,
+        notMultiplatformConfiguration = "api",
+        commonConfiguration = "commonMainApi",
+        targetConfiguration = KotlinTarget::apiConfigName,
+        limitToTargets = limitToTargets,
+    )
+}
+
+internal fun Project.addKspDependency(
+    dependency: Provider<MinimalExternalModuleDependency>?,
+    limitToTargets: Set<KotlinPlatformType>? = null,
+) {
+    addDependency(
+        dependency = dependency,
+        notMultiplatformConfiguration = "ksp",
+        commonConfiguration = "ksp",
+        targetConfiguration = KotlinTarget::kspConfigName,
+        limitToTargets = limitToTargets,
+    )
+}
+
+private fun Project.addDependency(
+    dependency: Provider<MinimalExternalModuleDependency>?,
+    notMultiplatformConfiguration: String,
+    commonConfiguration: String,
+    targetConfiguration: KotlinTarget.() -> String,
+    limitToTargets: Set<KotlinPlatformType>?,
+) {
+    if (dependency == null) {
+        return
+    }
+
+    val extension = kotlinExtension
+    if (extension is KotlinMultiplatformExtension) {
+        if (limitToTargets == null) {
+            dependencies.add(commonConfiguration, dependency)
+        } else {
+            extension.targets.configureEach {
+                if (it.platformType in limitToTargets) {
+                    dependencies.add(it.targetConfiguration(), dependency)
+                }
+            }
+        }
+    } else {
+        dependencies.add(notMultiplatformConfiguration, dependency)
+    }
+}
+
+internal fun KotlinTarget.apiConfigName(): String {
+    return when (targetName) {
+        "main" -> "api"
+        else -> "${targetName}MainApi"
+    }
+}
+
+internal fun KotlinTarget.kspConfigName(): String {
+    return when (targetName) {
+        "main" -> "ksp"
+        else -> "ksp${targetName.capitalize()}"
+    }
+}


### PR DESCRIPTION
With this `useDagger` will work in a multiplatform project and configure the Android and JVM targets of that project if available.

`useSerialization` is also compatible now, the only issue was that there is no `api` configuration in kmp projects.