### PR TITLE
stop setting buildFeatures.compose

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
@@ -63,7 +63,6 @@ public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
                 viewBinding = false
                 resValues = false
                 buildConfig = false
-                compose = false
                 dataBinding = false
                 aidl = false
                 renderScript = false


### PR DESCRIPTION
Whether compose is enabled is not controlled through build features anymore but instead by applying the compose plugin. So setting it to false by default doesn't make sense anymore and will lead to a warning.