### PR TITLE
opt-in to new data class copy visibility

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -97,6 +97,8 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                         "-Xjspecify-annotations=strict",
                         // Enhance not null annotated type parameter's types to definitely not null types (@NotNull T => T & Any)
                         "-Xenhance-type-parameter-types-to-def-not-null",
+                        // https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor
+                        "-Xconsistent-data-class-copy-visibility",
                     )
 
                     if (!isAndroid) {


### PR DESCRIPTION
Globally opts into the the new behavior that the `copy` function of a `data class` has the same visibility as the constructor to avoid having to add annotations for this case.

https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor