### PR TITLE
add wasm/wasi target

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -125,6 +125,11 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
                 nodejs()
             }
 
+            @OptIn(ExperimentalWasmDsl::class)
+            wasmWasi {
+                nodejs()
+            }
+
             linuxX64()
             linuxArm64()
 


### PR DESCRIPTION
Coroutines 1.9.0 now supports it so we can add it to our list of common targets.