### PR TITLE
add binaryen repo for web assembly to repository workaround

### DIFF
--- a/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
+++ b/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/SettingsPlugin.kt
@@ -177,5 +177,21 @@ public abstract class SettingsPlugin : Plugin<Settings> {
 
             content.filter { it.includeGroup("com.yarnpkg") }
         }
+
+        exclusiveContent { content ->
+            content.forRepository {
+                ivy { ivy ->
+                    ivy.name = "Binaryen Distributions"
+                    ivy.setUrl("https://github.com/WebAssembly/binaryen/releases/download")
+                    ivy.patternLayout {
+                        it.artifact("version_[revision]/[module]-version_[revision]-[classifier].[ext]")
+                    }
+                    ivy.metadataSources { it.artifact() }
+                    ivy.content { it.includeModule("com.github.webassembly", "binaryen") }
+                }
+            }
+
+            content.filter { it.includeGroup("com.github.webassembly") }
+        }
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
@@ -43,5 +43,10 @@ public abstract class FreeleticsMultiplatformPlugin : Plugin<Project> {
                 it.downloadBaseUrl = null
             }
         }
+        plugins.withType(org.jetbrains.kotlin.gradle.targets.js.binaryen.BinaryenRootPlugin::class.java) {
+            extensions.configure(org.jetbrains.kotlin.gradle.targets.js.binaryen.BinaryenRootExtension::class.java) {
+                it.downloadBaseUrl = null
+            }
+        }
     }
 }


### PR DESCRIPTION
Adds the same workaround that we already have for nodejs and yarn also for binaryen. We're requiring all repositories to be defined in `settings.gradle` and the Kotlin plugin dynamically adding more breaks this check.