### PR TITLE
add Anvil KSP to dependency analysis config

### DIFF
--- a/plugin-root/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
+++ b/plugin-root/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
@@ -111,6 +111,8 @@ public abstract class RootPlugin : Plugin<Project> {
                             "javax.inject:javax.inject",
                             "com.squareup.anvil:annotations",
                             "com.squareup.anvil:annotations-optional",
+                            "dev.zacsweers.anvil:annotations",
+                            "dev.zacsweers.anvil:annotations-optional",
                             "com.freeletics.khonshu:codegen-runtime",
                             "com.freeletics.khonshu:codegen-scope",
                         )
@@ -124,6 +126,8 @@ public abstract class RootPlugin : Plugin<Project> {
                             "javax.inject:javax.inject",
                             "com.squareup.anvil:annotations",
                             "com.squareup.anvil:annotations-optional",
+                            "dev.zacsweers.anvil:annotations",
+                            "dev.zacsweers.anvil:annotations-optional",
                             "com.freeletics.khonshu:codegen-runtime",
                             "com.freeletics.khonshu:codegen-scope",
                             "com.google.dagger:dagger",


### PR DESCRIPTION
We need to ignore the Anvil KSP artifacts in the same way that the regular Anvil dependencies are ignored.