### PR TITLE
remove SettingsExtension accessor

### DIFF
--- a/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
+++ b/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/SettingsExtension.kt
@@ -2,10 +2,6 @@ package com.freeletics.gradle.plugin
 
 import org.gradle.api.initialization.Settings
 
-public fun Settings.freeletics(configure: SettingsExtension.() -> Unit) {
-    extensions.configure(SettingsExtension::class.java, configure)
-}
-
 public abstract class SettingsExtension(private val settings: Settings) {
     /**
      * Automatically find and include Gradle projects in this build. It will start from the root folder and find any


### PR DESCRIPTION
Was made obsolete by https://github.com/gradle/gradle/pull/27999