### PR TITLE
remove obsolete compiler options

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -104,14 +104,6 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                     if (!isAndroid) {
                         freeCompilerArgs.add("-Xjdk-release=${project.javaTarget}")
                     }
-
-                    if (project.booleanProperty("fgp.kotlin.fastJarFs", false).get()) {
-                        freeCompilerArgs.add("-Xuse-fast-jar-file-system")
-                    }
-
-                    // TODO workaround for incremental issue when merging java resources
-                    //  https://issuetracker.google.com/issues/284003132
-                    moduleName.set(path.substring(1).replace(":", "_"))
                 }
             }
         }


### PR DESCRIPTION
- fast jar file system is on by default with k2
- the issue with the module name workaround was resolved in AGP 8.3.x