### PR TITLE
move CircleCI helper to it's own artifact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,14 @@ plugins {
 }
 
 dependencyAnalysis {
+    issues {
+        project(":scripts-circleci") {
+            onUnusedDependencies {
+                exclude(libs.clikt.asProvider())
+            }
+        }
+    }
+
     structure {
         bundle("slack") {
             includeGroup("com.slack.api")

--- a/scripts-circleci/README.md
+++ b/scripts-circleci/README.md
@@ -1,0 +1,26 @@
+# Slack Scripts
+
+This provides a `OptionGroup` helper called `CircleCiOptions` which gives access
+to common CircleCI values like the repository name, job number or branch.
+
+### Example usage
+
+```kts
+#!/usr/bin/env kotlin
+
+@file:DependsOn("com.freeletics.gradle:scripts-circleci:<latest-version>")
+
+import com.freeletics.gradle.scripts.CircleCiOptions
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.main
+
+class MyCli : CliktCommand() {
+    private val circleCi by CircleCiOptions()
+
+    override fun run() {
+        send("Hello from job ${circleCi.jobName}")
+    }
+}
+
+MyCli().main(args)
+```

--- a/scripts-circleci/gradle.properties
+++ b/scripts-circleci/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=scripts-circleci
+POM_NAME=CircleCI Script helpers
+POM_DESCRIPTION=Collection of CircleCI related kts helpers

--- a/scripts-circleci/scripts-circleci.gradle.kts
+++ b/scripts-circleci/scripts-circleci.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    alias(libs.plugins.fgp.jvm)
+    alias(libs.plugins.fgp.publish)
+}
+
+dependencies {
+    api(libs.kotlin.stdlib)
+    api(libs.clikt)
+    api(libs.clikt.core)
+}

--- a/scripts-circleci/src/main/kotlin/com/freeletics/gradle/scripts/CircleCiOptions.kt
+++ b/scripts-circleci/src/main/kotlin/com/freeletics/gradle/scripts/CircleCiOptions.kt
@@ -43,4 +43,10 @@ public class CircleCiOptions : OptionGroup("CircleCI options") {
         envvar = "CIRCLE_BRANCH",
         help = "The branch that was built",
     ).required()
+
+    public val commitSha1: String by option(
+        "--commit-sha1",
+        envvar = "CIRCLE_SHA1",
+        help = "The sha1 of the commit that was built",
+    ).required()
 }

--- a/scripts-slack/README.md
+++ b/scripts-slack/README.md
@@ -3,7 +3,6 @@
 Provides `SlackMessageCli` that makes it easy to write clikt scripts that send Slack messages.
 
 This also provides several `OptionGroup` helpers:
-- `CircleCiOptions`
 - `PlatformOptions`
 - `ReleaseTrainOptions`
 


### PR DESCRIPTION
- New artifact for `CircleCiOptions` since it's not tied to the Slack helpers. Also allows adding more CircleCI things here.
- Added `commitSha1` to available options