### PR TITLE
add CircleCI API to retrieve test results

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin) apply (false)
+    alias(libs.plugins.kotlin.serialization) apply (false)
     alias(libs.plugins.dependency.analysis) apply (false)
     alias(libs.plugins.publish) apply (false)
     alias(libs.plugins.dokka) apply (false)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ dokka = "1.9.20"
 
 clikt = "5.0.1"
 ktlint = "1.4.1"
+serialization = "1.7.3"
 
 junit = "4.13.2"
 truth = "1.4.4"
@@ -54,8 +55,10 @@ clikt-core = { module = "com.github.ajalt.clikt:clikt-core-jvm", version.ref = "
 ktlint-rule-engine = { module = "com.pinterest.ktlint:ktlint-rule-engine", version.ref = "ktlint" }
 ktlint-rule-engine-core = { module = "com.pinterest.ktlint:ktlint-rule-engine-core", version.ref = "ktlint" }
 ktlint-rules = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint" }
-
 slack = { module = "com.slack.api:slack-api-client-kotlin-extension", version = "1.44.1"}
+okhttp = { module = "com.squareup.okhttp3:okhttp", version = "4.12.0" }
+kotlinx-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json ", version.ref = "serialization" }
 
 junit = { module = "junit:junit", version.ref = "junit" }
 truth = { module = "com.google.truth:truth", version.ref = "truth" }
@@ -68,6 +71,7 @@ fgp-jvm = { id = "com.freeletics.gradle.jvm", version.ref = "fgp" }
 fgp-publish = { id = "com.freeletics.gradle.publish.oss", version.ref = "fgp" }
 
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 publish = { id = "com.vanniktech.maven.publish", version.ref = "publish" }

--- a/scripts-circleci/scripts-circleci.gradle.kts
+++ b/scripts-circleci/scripts-circleci.gradle.kts
@@ -3,8 +3,14 @@ plugins {
     alias(libs.plugins.fgp.publish)
 }
 
+freeletics {
+    useSerialization()
+}
+
 dependencies {
     api(libs.kotlin.stdlib)
     api(libs.clikt)
     api(libs.clikt.core)
+    implementation(libs.okhttp)
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/scripts-circleci/src/main/kotlin/com/freeletics/gradle/scripts/CircleCiClient.kt
+++ b/scripts-circleci/src/main/kotlin/com/freeletics/gradle/scripts/CircleCiClient.kt
@@ -1,0 +1,114 @@
+package com.freeletics.gradle.scripts
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+
+public class CircleCiClient(
+    private val token: String,
+) {
+    private val client = OkHttpClient()
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    /**
+     * https://circleci.com/docs/api/v2/index.html#tag/Job/operation/getTests
+     */
+    public fun getTestResults(options: CircleCiOptions): List<CircleCiTest>? {
+        return getTestResults(options.repoSlug, options.buildNumber)
+    }
+
+    /**
+     * https://circleci.com/docs/api/v2/index.html#tag/Job/operation/getTests
+     */
+    public fun getTestResults(repoSlug: String, buildNumber: String): List<CircleCiTest>? {
+        return getTestResults(repoSlug, buildNumber, pageToken = null)
+    }
+
+    /**
+     * https://circleci.com/docs/api/v2/index.html#tag/Job/operation/getTests
+     */
+    private fun getTestResults(repoSlug: String, buildNumber: String, pageToken: String?): List<CircleCiTest>? {
+        val url = "https://circleci.com/api/v2/project/github/$repoSlug/$buildNumber/tests".toHttpUrl()
+            .newBuilder()
+            .addQueryParameter("page-token", pageToken)
+            .build()
+
+        val request = Request.Builder()
+            .get()
+            .url(url)
+            .header("Circle-Token", token)
+            .build()
+
+        val response = client.newCall(request).execute()
+        if (response.isSuccessful) {
+            val body = response.body?.string()
+            if (body != null) {
+                val testsResponse = json.decodeFromString<CircleCiTestsResponse>(body)
+                if (testsResponse.nextPageToken == null) {
+                    return testsResponse.items
+                }
+                val remainingPages = getTestResults(repoSlug, buildNumber, testsResponse.nextPageToken)
+                if (remainingPages == null) {
+                    // this means one of the subsequent calls failed, return null instead of a partial result
+                    return null
+                }
+                return testsResponse.items + remainingPages
+            }
+        }
+        println("Request failed with ${response.code} ${response.body?.string()}")
+        return null
+    }
+}
+
+/**
+ * https://circleci.com/docs/api/v2/index.html#tag/Job/operation/getTests
+ *
+ * @param items
+ * @param nextPageToken A token to pass as a page-token query parameter to return the next page of results.
+ */
+@Serializable
+private data class CircleCiTestsResponse(
+    val items: List<CircleCiTest>,
+    @SerialName("next_page_token")
+    val nextPageToken: String?,
+)
+
+/**
+ * https://circleci.com/docs/api/v2/index.html#tag/Job/operation/getTests
+ *
+ * @param name The name of the test.
+ * @param classname The programmatic location of the test.
+ * @param file The file in which the test is defined.
+ * @param result Indication of whether the test succeeded.
+ * @param message The failure message associated with the test.
+ * @param source The program that generated the test results
+ * @param runtime The time it took to run the test in seconds
+ */
+@Serializable
+public data class CircleCiTest(
+    val name: String,
+    val classname: String,
+    val file: String? = null,
+    val result: Result,
+    val message: String,
+    val source: String,
+    @SerialName("run_time")
+    val runtime: Double,
+)
+
+@Serializable
+public enum class Result {
+    @SerialName("success")
+    SUCCESS,
+
+    @SerialName("failure")
+    FAILURE,
+
+    @SerialName("skipped")
+    SKIPPED,
+}


### PR DESCRIPTION
Since kotlinx.serialization uses a compiler plugin we can't easily use it in scripts. Having this here we can have proper models for the response instead of having to deal with maps and string based keys.