### PR TITLE
fix json key for GoogleSheetsReader

### DIFF
--- a/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GoogleSheetsReader.kt
+++ b/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GoogleSheetsReader.kt
@@ -7,7 +7,6 @@ import com.google.api.services.sheets.v4.SheetsScopes.SPREADSHEETS_READONLY
 import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.GoogleCredentials
 import java.io.ByteArrayInputStream
-import java.util.Base64
 
 public class GoogleSheetsReader(applicationName: String, jsonKey: String) {
     private val credentials = GoogleCredentials.fromStream(ByteArrayInputStream(jsonKey.toByteArray()))

--- a/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GoogleSheetsReader.kt
+++ b/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GoogleSheetsReader.kt
@@ -10,7 +10,7 @@ import java.io.ByteArrayInputStream
 import java.util.Base64
 
 public class GoogleSheetsReader(applicationName: String, jsonKey: String) {
-    private val credentials = GoogleCredentials.fromStream(ByteArrayInputStream(Base64.getDecoder().decode(jsonKey)))
+    private val credentials = GoogleCredentials.fromStream(ByteArrayInputStream(jsonKey.toByteArray()))
         .createScoped(listOf(SPREADSHEETS_READONLY))
 
     private val sheets = Sheets.Builder(


### PR DESCRIPTION
The `GoogleApiOptions` helper already takes care of the base64 decoding, so it's duplicated here.