### PR TITLE
fix S3 Content-Type for html files

### DIFF
--- a/scripts-s3/src/main/kotlin/com/freeletics/gradle/scripts/S3Uploader.kt
+++ b/scripts-s3/src/main/kotlin/com/freeletics/gradle/scripts/S3Uploader.kt
@@ -29,7 +29,7 @@ private suspend fun upload(stream: ByteStream, options: BaseS3Options): String {
             key = options.key
             body = stream
             if (options.key.endsWith(".html")) {
-                metadata = mapOf("Content-Type" to "text/html")
+                contentType = "text/html"
             }
         }
 


### PR DESCRIPTION
Setting it through metadata results in a different key:
![Screenshot 2024-11-28 at 14 10 01](https://github.com/user-attachments/assets/4102e50a-26a7-4fe0-b40c-d774b1d89a83)
