### PR TITLE
disable progressive mode for kapt stub generation

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -107,5 +107,12 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                 }
             }
         }
+
+        // TODO remove when updating to Kotlin 2.1.20 https://youtrack.jetbrains.com/issue/KT-64385
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs::class.java).configureEach {
+            it.compilerOptions {
+                progressiveMode.set(booleanProperty("kapt.use.k2", false))
+            }
+        }
     }
 }


### PR DESCRIPTION
It's currently still using k1 (language level 1.9) and fails if progressive mode is enabled with Kotlin 2.1.0