### PR TITLE
make changes for Kotlin 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Change Log
 ==========
 
+## 0.20.0 **UNRELEASED**
+
+- Updated to Kotlin 2.1.0
+- Enable new Kotlin language features
+  - [Guard conditions in when with a subject](https://kotlinlang.org/docs/whatsnew21.html#guard-conditions-in-when-with-a-subject) (`-Xwhen-guards`),
+  - [Non-local break and continue](https://kotlinlang.org/docs/whatsnew21.html#non-local-break-and-continue) (`-Xnon-local-break-continue`)
+  - [Multi-dollar string interpolation](https://kotlinlang.org/docs/whatsnew21.html#multi-dollar-string-interpolation) (`-Xmulti-dollar-interpolation`)
+- New Gradle properties to configure Kotlin compiler daemon:
+  - enable [`extraWarnings` option](https://kotlinlang.org/docs/whatsnew21.html#extra-compiler-checks) in the
+    compiler by default, can be disabled by setting `fgp.kotlin.extraWarnings=false`
+  - replaced the `fgp.kotlin.allowWarnings` property with `fgp.kotlin.warningsAsErrors` (defaults to true)
+  - allow easily suppressing deprecation warnings by setting `fgp.kotlin.suppressDeprecationWarnings=true`
+    (defaults to false)
+
+
 ## 0.19.2 *(2024-12-02)*
 
 - Disable progressive mode for kapt stub generation when not using K2.

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -74,7 +74,11 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                     ?.let(KotlinVersion::fromVersion) ?: KotlinVersion.DEFAULT
                 languageVersion.set(version)
 
-                allWarningsAsErrors.set(!booleanProperty("fgp.kotlin.allowWarnings", false).get())
+                extraWarnings.set(booleanProperty("fgp.kotlin.extraWarnings", true))
+                allWarningsAsErrors.set(booleanProperty("fgp.kotlin.warningsAsErrors", true))
+                if (booleanProperty("fgp.kotlin.suppressDeprecationWarnings", false).get()) {
+                    freeCompilerArgs.add("-Xsuppress-warning=DEPRECATION")
+                }
 
                 // In this mode, some deprecations and bug-fixes for unstable code take effect immediately.
                 progressiveMode.set(version >= KotlinVersion.DEFAULT)
@@ -82,6 +86,9 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                 // Support inferring type arguments based on only self upper bounds of the corresponding type parameters
                 // https://kotlinlang.org/docs/whatsnew1530.html#improvements-to-type-inference-for-recursive-generic-types
                 freeCompilerArgs.add("-Xself-upper-bound-inference")
+
+                // Kotlin 2.1 experimental language features
+                freeCompilerArgs.addAll("-Xwhen-guards", "-Xnon-local-break-continue", "-Xmulti-dollar-interpolation")
 
                 if (this is KotlinJvmCompilerOptions) {
                     jvmTarget.set(project.jvmTarget)

--- a/plugins/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
@@ -12,7 +12,6 @@ import com.freeletics.gradle.plugin.FreeleticsJvmExtension
 import com.freeletics.gradle.plugin.FreeleticsMultiplatformExtension
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
-import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.HasConfigurableKotlinCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
@@ -42,7 +41,6 @@ internal fun Project.kotlin(action: KotlinProjectExtension.() -> Unit) {
     (project.extensions.getByName("kotlin") as KotlinProjectExtension).action()
 }
 
-@OptIn(ExperimentalKotlinGradlePluginApi::class)
 internal fun KotlinProjectExtension.compilerOptions(configure: KotlinCommonCompilerOptions.() -> Unit) {
     when (this) {
         is KotlinJvmProjectExtension -> compilerOptions(configure)


### PR DESCRIPTION
- enable extraWarnings in the compiler by default, can be disabled by setting `fgp.kotlin.extraWarnings=false`
- allow easily suppressing deprecation warnings by setting `fgp.kotlin.suppressDeprecationWarnings =true` (defaults to false)
- for consistency replaced `fgp.kotlin.allowWarnings` with `fgp.kotlin.warningsAsErrors` so that we don't need to invert the boolean
- enable new Kotlin language features
- remove obsolete OptIn