### PR TITLE
also include OVERRIDE_DEPRECATION when suppressing deprecation warnings

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -78,6 +78,7 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                 allWarningsAsErrors.set(booleanProperty("fgp.kotlin.warningsAsErrors", true))
                 if (booleanProperty("fgp.kotlin.suppressDeprecationWarnings", false).get()) {
                     freeCompilerArgs.add("-Xsuppress-warning=DEPRECATION")
+                    freeCompilerArgs.add("-Xsuppress-warning=OVERRIDE_DEPRECATION")
                 }
 
                 // In this mode, some deprecations and bug-fixes for unstable code take effect immediately.


### PR DESCRIPTION
Also suppressed these kinds of warnings `This declaration overrides a deprecated member but is not marked as deprecated itself. Please add the '@Deprecated' annotation or suppress the diagnostic.` when `fgp.kotlin.suppressDeprecationWarnings` was set to true.