### PR TITLE
Add `com.google.mediapipe` as group to Google repository

### DIFF
--- a/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/Repositories.kt
+++ b/plugin-settings/src/main/kotlin/com/freeletics/gradle/plugin/Repositories.kt
@@ -44,6 +44,7 @@ internal fun RepositoryHandler.addGoogleRepository() {
         includeVersionByRegex("^androidx\\..*", ".*", ".*(?<!-SNAPSHOT)\$")
         includeGroupByRegex("^com.google.android.*")
         includeGroup("com.google.firebase")
+        includeGroup("com.google.mediapipe")
         includeGroup("com.google.testing.platform")
         includeGroup("com.google.android.apps.common.testing.accessibility.framework")
     }


### PR DESCRIPTION
Added so that `com.google.mediapipe:tasks-vision` can be used as a dependency.