### PR TITLE
add annotation-default-target compiler option for behavior

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -91,6 +91,9 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                 // Kotlin 2.1 experimental language features
                 freeCompilerArgs.addAll("-Xwhen-guards", "-Xnon-local-break-continue", "-Xmulti-dollar-interpolation")
 
+                // https://youtrack.jetbrains.com/issue/KT-73255
+                freeCompilerArgs.add("-Xannotation-default-target=param-property")
+
                 if (this is KotlinJvmCompilerOptions) {
                     jvmTarget.set(project.jvmTarget)
 


### PR DESCRIPTION
Avoids that we have to give all existing annotations an explicit use target https://youtrack.jetbrains.com/issue/KT-73255