### PR TITLE
add setup for metro

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ javax-inject = { module = "javax.inject:javax.inject", version = "1" }
 
 android-gradle = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
 ksp-gradle = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin",  version.ref = "ksp" }
+metro-gradle = { module = "dev.zacsweers.metro:gradle-plugin", version = "0.2.0" }
 poko-gradle = { module = "dev.drewhamilton.poko:poko-gradle-plugin", version = "0.18.6" }
 kopy-gradle = { module = "com.javiersc.kotlin:kopy-gradle-plugin", version = "0.15.0+2.1.20" }
 skie-gradle = { module = "co.touchlab.skie:gradle-plugin", version = "0.10.1" }

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     implementation(libs.kotlin.gradle.annotations)
     implementation(libs.kotlin.native.utils)
     implementation(libs.ksp.gradle)
+    implementation(libs.metro.gradle)
     implementation(libs.dependency.analysis)
     implementation(libs.publish)
     implementation(libs.licensee)

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -1,6 +1,8 @@
 package com.freeletics.gradle.plugin
 
 import com.freeletics.gradle.setup.configureDagger
+import com.freeletics.gradle.setup.configureKhonshu
+import com.freeletics.gradle.setup.configureMetro
 import com.freeletics.gradle.setup.setupCompose
 import com.freeletics.gradle.util.addApiDependency
 import com.freeletics.gradle.util.compilerOptions
@@ -32,6 +34,15 @@ public abstract class FreeleticsBaseExtension(private val project: Project) : Ex
         project.plugins.apply("org.jetbrains.kotlin.plugin.serialization")
 
         project.addApiDependency(project.getDependency("kotlinx-serialization"))
+    }
+
+    public fun useMetro() {
+        project.configureMetro()
+    }
+
+    public fun useKhonshu() {
+        project.configureMetro()
+        project.configureKhonshu()
     }
 
     public fun useDagger() {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
@@ -102,16 +102,6 @@ public abstract class RootPlugin : Plugin<Project> {
                             "com.freeletics.gradle:minify-common",
                             // added automatically to all app modules with crash reporting
                             "com.freeletics.gradle:minify-crashlytics",
-                            // added automatically when enabling Dagger but not all of them might be used
-                            // the Dagger runtime is not listed here and it being marked as unused is the indicator
-                            // to remove useDagger from the module
-                            "javax.inject:javax.inject",
-                            "com.squareup.anvil:annotations",
-                            "com.squareup.anvil:annotations-optional",
-                            "dev.zacsweers.anvil:annotations",
-                            "dev.zacsweers.anvil:annotations-optional",
-                            "com.freeletics.khonshu:codegen-runtime",
-                            "com.freeletics.khonshu:codegen-scope",
                         )
                     }
 
@@ -119,16 +109,6 @@ public abstract class RootPlugin : Plugin<Project> {
                         it.exclude(
                             // added by the Kotlin plugin
                             "org.jetbrains.kotlin:kotlin-stdlib",
-                            // Dagger is always added as "api", but some modules only use it in for example debugApi
-                            "javax.inject:javax.inject",
-                            "com.squareup.anvil:annotations",
-                            "com.squareup.anvil:annotations-optional",
-                            "dev.zacsweers.anvil:annotations",
-                            "dev.zacsweers.anvil:annotations-optional",
-                            "com.freeletics.khonshu:codegen-runtime",
-                            "com.freeletics.khonshu:codegen-scope",
-                            "com.google.dagger:dagger",
-                            "com.google.dagger:dagger-compiler",
                             // Room is always added as "api", but some modules only use it in for example debugApi
                             "androidx.room:room-runtime",
                             // Kotlinx.serialization is always added as "api", but some modules only use it in for example debugApi


### PR DESCRIPTION
- add `useMetro()` that adds Metro
- add `useKhonshu()` that adds Metro + Khonshu
- add `fgp.metro.migrationEnabled` property that makes the existing `useDagger...()` methods use Metro instead
- add `fgp.metro.interop` that in the migration mode enables Metro's interop with Dagger/Anvil annotations