### PR TITLE
Fix compiler args for Kotlin 2.2

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -143,8 +143,10 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                     )
 
                     if (version >= KotlinVersion.KOTLIN_2_2) {
-                        // https://kotlinlang.org/docs/whatsnew-eap.html#support-for-reading-and-writing-annotations-in-kotlin-metadata
-                        "-Xannotations-in-metadata"
+                        freeCompilerArgs.addAll(
+                            // https://kotlinlang.org/docs/whatsnew-eap.html#support-for-reading-and-writing-annotations-in-kotlin-metadata
+                            "-Xannotations-in-metadata",
+                        )
                     }
 
                     if (!isAndroid) {


### PR DESCRIPTION
Compiler args weren't wrapped into `addAll()`.