### PR TITLE
add paparazzi configurations to platform

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/Platform.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/Platform.kt
@@ -13,15 +13,14 @@ internal fun Project.applyPlatformConstraints() {
 
 // adapted from https://github.com/ZacSweers/CatchUp/blob/347db46d82497990ff10c441ecc75c0c9eedf7c4/buildSrc/src/main/kotlin/dev/zacsweers/catchup/gradle/CatchUpPlugin.kt#L68-L80
 private fun isPlatformConfigurationName(name: String): Boolean {
-    // Kapt, ksp and compileOnly are special cases since they can be combined with others
-    if (name.startsWith("kapt", ignoreCase = true) ||
-        name.startsWith("ksp", ignoreCase = true) ||
-        name == "compileOnly"
-    ) {
-        return true
+    // Try trimming the flavor by just matching the prefix
+    PLATFORM_CONFIGURATION_PREFIX.forEach { platformConfig ->
+        if (name.startsWith(platformConfig, ignoreCase = true)) {
+            return true
+        }
     }
     // Try trimming the flavor by just matching the suffix
-    PLATFORM_CONFIGURATIONS.forEach { platformConfig ->
+    PLATFORM_CONFIGURATION_SUFFIX.forEach { platformConfig ->
         if (name.endsWith(platformConfig, ignoreCase = true)) {
             return true
         }
@@ -29,7 +28,13 @@ private fun isPlatformConfigurationName(name: String): Boolean {
     return false
 }
 
-private val PLATFORM_CONFIGURATIONS = setOf(
+private val PLATFORM_CONFIGURATION_PREFIX = setOf(
+    "kapt",
+    "ksp",
+    "layoutlib",
+)
+
+private val PLATFORM_CONFIGURATION_SUFFIX = setOf(
     "api",
     "coreLibraryDesugaring",
     "compileOnly",
@@ -37,4 +42,7 @@ private val PLATFORM_CONFIGURATIONS = setOf(
     "kapt",
     "ksp",
     "runtimeOnly",
+    "androidTestUtil",
+    "lintChecks",
+    "lintRelease",
 )


### PR DESCRIPTION
Makes it easier to force a new layoutlib version by simply adding it to the version catalog.