### PR TITLE
more changes for Github Actions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,11 @@ dependencyAnalysis {
                 exclude(libs.clikt.asProvider())
             }
         }
+        project(":scripts-github") {
+            onUnusedDependencies {
+                exclude(libs.clikt.asProvider())
+            }
+        }
         project(":scripts-google") {
             onUnusedDependencies {
                 exclude(libs.clikt.asProvider())

--- a/scripts-github/scripts-github.gradle.kts
+++ b/scripts-github/scripts-github.gradle.kts
@@ -5,5 +5,6 @@ plugins {
 
 dependencies {
     api(libs.kotlin.stdlib)
+    api(libs.clikt)
     api(libs.clikt.core)
 }

--- a/scripts-github/src/main/kotlin/com/freeletics/gradle/scripts/GithubOptions.kt
+++ b/scripts-github/src/main/kotlin/com/freeletics/gradle/scripts/GithubOptions.kt
@@ -11,20 +11,29 @@ public class GithubOptions : OptionGroup("Github options") {
         help = "The username that this project belongs to",
     ).required()
 
-    private val repoSlug: String by option(
+    public val repoSlug: String by option(
         "--project-repository",
         envvar = "GITHUB_REPOSITORY",
-        help = "The repository ",
+        help = "The repository for this project",
     ).required()
 
     public val repoName: String
         get() = repoSlug.split("/")[1]
 
+    private val serverUrl: String by option(
+        "--server-url",
+        envvar = "GITHUB_SERVER_URL",
+        help = "The repository for this project",
+    ).required()
+
+    public val runId: String by option(
+        "--run-id",
+        envvar = "GITHUB_RUN_ID",
+        help = "The repository for this project",
+    ).required()
+
     public val jobUrl: String
-        get() = System.getenv("GITHUB_SERVER_URL") + "/" +
-            System.getenv("GITHUB_REPOSITORY") + "/" +
-            "actions/runs/" +
-            System.getenv("GITHUB_RUN_ID")
+        get() = "$serverUrl/$repoSlug/actions/runs/$runId"
 
     public val jobName: String by option(
         "--job-name",

--- a/scripts-slack/src/main/kotlin/com/freeletics/gradle/scripts/ReleaseTrainOptions.kt
+++ b/scripts-slack/src/main/kotlin/com/freeletics/gradle/scripts/ReleaseTrainOptions.kt
@@ -25,7 +25,7 @@ public class ReleaseTrainOptions : OptionGroup("Release Train options") {
 
     public val branch: String by option(
         "--branch",
-        envvar = "CIRCLE_BRANCH",
+        envvar = "GITHUB_REF_NAME",
         help = "The branch of the release train",
     ).required()
 }


### PR DESCRIPTION
- add `libs.clikt` to the artifact and ignore it in `buildHealth` so that we can just rely on this to bring in the dependency like we do for other script helpers
- expose `repoSlug` publicly
- make `jobUrl` a bit more consistent with other options
- update the `envVar` for `--branch` in `ReleaseTrainOptions`