### PR TITLE
disable NewerVersionAvailable lint check

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidLintSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidLintSetup.kt
@@ -29,6 +29,8 @@ internal fun Lint.configure(project: Project) {
     textReport = true
     textOutput = project.reportsFile("lint-result.txt").get().asFile
 
+    disable += "NewerVersionAvailable"
+
     project.dependencies.addMaybe("lintChecks", project.getBundleOrNull("default-lint"))
 }
 


### PR DESCRIPTION
Can cause random CI failures since we enable warning as errors.