### PR TITLE
add packagingOptions for native androidx libraries

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppPlugin.kt
@@ -67,9 +67,9 @@ public abstract class AppPlugin : Plugin<Project> {
                 }
             }
 
-            // avoid "Unable to strip the following libraries, packaging them as they are" messages
-            packagingOptions {
-                jniLibs.keepDebugSymbols.addAll(
+            packaging {
+                // avoid "Unable to strip the following libraries, packaging them as they are" messages
+                jniLibs.keepDebugSymbols += setOf(
                     "**/libandroidx.graphics.path.so",
                     "**/libdatastore_shared_counter.so",
                 )

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppPlugin.kt
@@ -67,6 +67,14 @@ public abstract class AppPlugin : Plugin<Project> {
                 }
             }
 
+            // avoid "Unable to strip the following libraries, packaging them as they are" messages
+            packagingOptions {
+                jniLibs.keepDebugSymbols.addAll(
+                    "**/libandroidx.graphics.path.so",
+                    "**/libdatastore_shared_counter.so",
+                )
+            }
+
             lint {
                 baseline = target.file("lint-baseline.xml")
             }


### PR DESCRIPTION
Adding this to avoid "Unable to strip the following libraries, packaging them as they are" messages for AndroidX libraries.