### PR TITLE
expose Google Play rollout percentage and downloadApk function

### DIFF
--- a/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GooglePlayEdit.kt
+++ b/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GooglePlayEdit.kt
@@ -84,7 +84,7 @@ public class GooglePlayEdit(
     }
 
     private fun List<TrackRelease>.toVersions() = flatMap { release ->
-        release.versionCodes.map { GooglePlayReleaseVersion(release.name, it) }
+        release.versionCodes.map { GooglePlayReleaseVersion.WithRollout(release.name, it, release.userFraction) }
     }
 
     public companion object {

--- a/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GooglePlayPublisher.kt
+++ b/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GooglePlayPublisher.kt
@@ -7,6 +7,7 @@ import com.google.api.services.androidpublisher.AndroidPublisherScopes.ANDROIDPU
 import com.google.api.services.androidpublisher.model.AppEdit
 import com.google.auth.oauth2.GoogleCredentials
 import java.io.ByteArrayInputStream
+import java.io.File
 import kotlin.time.Duration.Companion.minutes
 
 public class GooglePlayPublisher(
@@ -39,6 +40,15 @@ public class GooglePlayPublisher(
         } catch (t: Throwable) {
             androidPublisher.edits().delete(appId, edit.id).execute()
             throw t
+        }
+    }
+
+    public fun downloadApkTo(file: File, versionCode: Int) {
+        val result = androidPublisher.generatedapks().list(appId, versionCode).execute()
+        val universalApk = result.generatedApks.single().generatedUniversalApk
+        val request = androidPublisher.generatedapks().download(appId, versionCode, universalApk.downloadId)
+        file.outputStream().use {
+            request.executeMediaAndDownloadTo(it)
         }
     }
 }

--- a/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GooglePlayReleaseVersion.kt
+++ b/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GooglePlayReleaseVersion.kt
@@ -1,17 +1,35 @@
 package com.freeletics.gradle.scripts
 
-public data class GooglePlayReleaseVersion(
-    val name: String,
-    val code: Long,
-) {
-    val namePrefix: String get() = name.split(".").run {
+public sealed class GooglePlayReleaseVersion() {
+
+    public abstract val name: String
+    public abstract val code: Long
+
+    public val namePrefix: String get() = name.split(".").run {
         check(size == 3) { "Invalid version $name" }
         "${get(0)}.${get(1)}"
     }
 
-    val codePrefix: Long get() = code / 1000
+    public val codePrefix: Long get() = code / 1000
 
-    override fun toString(): String {
-        return "$name ($code)"
+    public data class Simple(
+        override val name: String,
+        override val code: Long,
+    ) : GooglePlayReleaseVersion() {
+        override fun toString(): String {
+            return "$name ($code)"
+        }
     }
+
+    public data class WithRollout(
+        override val name: String,
+        override val code: Long,
+        val rolloutPercentage: Double
+    ) : GooglePlayReleaseVersion() {
+        public fun asSimple(): GooglePlayReleaseVersion = Simple(name, code)
+
+        override fun toString(): String {
+            return "$name ($code) @ ${rolloutPercentage}"
+        }
+   }
 }


### PR DESCRIPTION
Makes it easier to access these from scripts. The universal apk download will allow us to stop building both an aab and an apk which currently can't happen in the same Gradle invocation since they are signed differently (upload vs real keys).