### PR TITLE
handle userFraction being null

### DIFF
--- a/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GooglePlayEdit.kt
+++ b/scripts-google/src/main/kotlin/com/freeletics/gradle/scripts/GooglePlayEdit.kt
@@ -84,7 +84,7 @@ public class GooglePlayEdit(
     }
 
     private fun List<TrackRelease>.toVersions() = flatMap { release ->
-        release.versionCodes.map { GooglePlayReleaseVersion.WithRollout(release.name, it, release.userFraction) }
+        release.versionCodes.map { GooglePlayReleaseVersion.WithRollout(release.name, it, release.userFraction ?: 1.0) }
     }
 
     public companion object {


### PR DESCRIPTION
`userFraction` is only set if the rollout is in progress or halted, so if it's not here we're now assuming 100% (since it's a release inside a track it shouldn't be 0%).