### PR TITLE
handle ios artifacts in platform

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
@@ -41,17 +41,11 @@ public abstract class RootPlugin : Plugin<Project> {
 
                     constraints.add("api", library)
 
-                    // if this is a ktx library also add the non ktx artifact to the platform
-                    if (module.name.endsWith("-ktx")) {
-                        constraints.add("api", "${module.group}:${module.name.replace("-ktx", "")}:$version")
-                    }
-                    // for KMP modules where the platform artifact is specified also add the common artifact
-                    if (module.name.endsWith("-jvm")) {
-                        constraints.add("api", "${module.group}:${module.name.replace("-jvm", "")}:$version")
-                    }
-                    // for KMP modules where the platform artifact is specified also add the common artifact
-                    if (module.name.endsWith("-android")) {
-                        constraints.add("api", "${module.group}:${module.name.replace("-android", "")}:$version")
+                    // if this is a ktx or kmp library also add the artifact to the platform without a suffix
+                    listOf("-ktx", "-jvm", "-android", "-iosarm64", "-iossimulatorarm64").forEach {
+                        if (module.name.endsWith(it)) {
+                            constraints.add("api", "${module.group}:${module.name.replace(it, "")}:$version")
+                        }
                     }
                     // add all Kotlin stdlib variations
                     if (module.group == "org.jetbrains.kotlin" && module.name == "kotlin-stdlib") {


### PR DESCRIPTION
This way if you have an `-iosarm64` or `-iossimulatorarm64` artifact in a version catalog you don't need to specify the version without suffix to force it to the same version as the others.