### PR TITLE
add useAndroidLint to multiplatform extension

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -1,5 +1,6 @@
 package com.freeletics.gradle.plugin
 
+import com.freeletics.gradle.setup.configureStandaloneLint
 import com.freeletics.gradle.util.kotlinMultiplatform
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -185,5 +186,11 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
 
     public fun useSkie() {
         project.plugins.apply("co.touchlab.skie")
+    }
+
+    public fun useAndroidLint() {
+        project.plugins.apply("com.android.lint")
+
+        project.configureStandaloneLint()
     }
 }


### PR DESCRIPTION
Allows to enable and configure Android Lint for mpp projects.