### PR TITLE
Multiplatform monorepo plugins

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ metro-gradle = { module = "dev.zacsweers.metro:gradle-plugin", version = "0.5.0"
 poko-gradle = { module = "dev.drewhamilton.poko:poko-gradle-plugin", version = "0.19.1" }
 kopy-gradle = { module = "com.javiersc.kotlin:kopy-gradle-plugin", version = "0.16.3+2.1.21" }
 skie-gradle = { module = "co.touchlab.skie:gradle-plugin", version = "0.10.4" }
+compose-gradle = { module = "org.jetbrains.compose:compose-gradle-plugin", version = "1.8.2"}
 sqldelight-gradle = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight" }
 paparazzi-gradle = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version.ref = "paparazzi" }
 

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.kotlin.native.utils)
     implementation(libs.ksp.gradle)
     implementation(libs.sqldelight.gradle)
+    implementation(libs.compose.gradle)
     implementation(libs.dependency.analysis.gradle)
     implementation(libs.publish.gradle)
     implementation(libs.licensee.gradle)
@@ -78,9 +79,14 @@ gradlePlugin {
             implementationClass = "com.freeletics.gradle.plugin.RootPlugin"
         }
 
-        create("monoAppPlugin") {
-            id = "com.freeletics.gradle.app"
-            implementationClass = "com.freeletics.gradle.monorepo.plugin.AppPlugin"
+        create("monoAppAndroidPlugin") {
+            id = "com.freeletics.gradle.app.android"
+            implementationClass = "com.freeletics.gradle.monorepo.plugin.AppAndroidPlugin"
+        }
+
+        create("monoAppMultiplatformPlugin") {
+            id = "com.freeletics.gradle.app.multiplatform"
+            implementationClass = "com.freeletics.gradle.monorepo.plugin.AppMultiplatformPlugin"
         }
 
         create("monoCoreAndroidPlugin") {
@@ -103,14 +109,24 @@ gradlePlugin {
             implementationClass = "com.freeletics.gradle.monorepo.plugin.DomainKotlinPlugin"
         }
 
-        create("monoFeaturePlugin") {
-            id = "com.freeletics.gradle.feature"
-            implementationClass = "com.freeletics.gradle.monorepo.plugin.FeaturePlugin"
+        create("monoFeatureAndroidPlugin") {
+            id = "com.freeletics.gradle.feature.android"
+            implementationClass = "com.freeletics.gradle.monorepo.plugin.FeatureAndroidPlugin"
         }
 
-        create("monoNavPlugin") {
-            id = "com.freeletics.gradle.nav"
-            implementationClass = "com.freeletics.gradle.monorepo.plugin.NavPlugin"
+        create("monoFeatureMultiplatformPlugin") {
+            id = "com.freeletics.gradle.feature.multiplatform"
+            implementationClass = "com.freeletics.gradle.monorepo.plugin.FeatureMultiplatformPlugin"
+        }
+
+        create("monoNavAndroidPlugin") {
+            id = "com.freeletics.gradle.nav.android"
+            implementationClass = "com.freeletics.gradle.monorepo.plugin.NavAndroidPlugin"
+        }
+
+        create("monoNavMultiplatformPlugin") {
+            id = "com.freeletics.gradle.nav.multiplatform"
+            implementationClass = "com.freeletics.gradle.monorepo.plugin.NavMultiplatformPlugin"
         }
 
         create("monoLegacyAndroidPlugin") {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppAndroidExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppAndroidExtension.kt
@@ -23,7 +23,7 @@ import com.freeletics.gradle.util.getVersion
 import java.io.File
 import org.gradle.api.Project
 
-public abstract class AppExtension(private val project: Project) {
+public abstract class AppAndroidExtension(private val project: Project) {
     public fun applicationId(applicationId: String) {
         project.androidApp {
             defaultConfig.applicationId = applicationId

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppAndroidPlugin.kt
@@ -14,11 +14,11 @@ import com.freeletics.gradle.util.stringProperty
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-public abstract class AppPlugin : Plugin<Project> {
+public abstract class AppAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsAndroidAppPlugin::class.java)
 
-        target.freeleticsExtension.extensions.create("app", AppExtension::class.java)
+        target.freeleticsExtension.extensions.create("app", AppAndroidExtension::class.java)
 
         target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
         target.freeleticsAndroidExtension.enableBuildConfig()
@@ -125,6 +125,7 @@ public abstract class AppPlugin : Plugin<Project> {
                 ProjectType.FEATURE_IMPLEMENTATION,
                 ProjectType.FEATURE_NAV,
                 ProjectType.LEGACY,
+                ProjectType.APP,
             ),
         )
 

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppDesktopPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppDesktopPlugin.kt
@@ -1,0 +1,57 @@
+package com.freeletics.gradle.monorepo.plugin
+
+import com.freeletics.gradle.monorepo.setup.applyPlatformConstraints
+import com.freeletics.gradle.monorepo.setup.disableMultiplatformApplicationTasks
+import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
+import com.freeletics.gradle.monorepo.util.ProjectType
+import com.freeletics.gradle.plugin.FreeleticsMultiplatformPlugin
+import com.freeletics.gradle.setup.defaultPackageName
+import com.freeletics.gradle.util.freeleticsMultiplatformExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.jetbrains.compose.ComposeExtension
+import org.jetbrains.compose.desktop.DesktopExtension
+import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+
+public abstract class AppDesktopPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply(FreeleticsMultiplatformPlugin::class.java)
+        target.plugins.apply("org.jetbrains.compose")
+
+        target.freeleticsMultiplatformExtension.addJvmTarget()
+
+        target.freeleticsMultiplatformExtension.useAndroidLint()
+
+        target.extensions.configure(ComposeExtension::class.java) { compose ->
+            compose.extensions.configure(DesktopExtension::class.java) { desktop ->
+                desktop.application { app ->
+                    app.mainClass = "${target.defaultPackageName()}.AppKt"
+                    app.nativeDistributions {
+                        it.targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
+                        it.packageName = target.defaultPackageName()
+                        // TODO compute version from task
+                        it.packageVersion = "1.0.0"
+                    }
+                }
+            }
+        }
+
+        target.registerCheckDependencyRulesTasks(
+            allowedProjectTypes = listOf(ProjectType.APP),
+            allowedDependencyProjectTypes = listOfNotNull(
+                ProjectType.CORE_API,
+                ProjectType.CORE_IMPLEMENTATION,
+                ProjectType.CORE_TESTING,
+                ProjectType.DOMAIN_API,
+                ProjectType.DOMAIN_IMPLEMENTATION,
+                ProjectType.DOMAIN_TESTING,
+                ProjectType.FEATURE_IMPLEMENTATION,
+                ProjectType.FEATURE_NAV,
+                ProjectType.APP,
+            ),
+        )
+
+        target.applyPlatformConstraints(multiplatform = true)
+        target.disableMultiplatformApplicationTasks()
+    }
+}

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/AppMultiplatformPlugin.kt
@@ -1,0 +1,45 @@
+package com.freeletics.gradle.monorepo.plugin
+
+import com.freeletics.gradle.monorepo.setup.applyPlatformConstraints
+import com.freeletics.gradle.monorepo.setup.disableMultiplatformLibraryTasks
+import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
+import com.freeletics.gradle.monorepo.util.ProjectType
+import com.freeletics.gradle.monorepo.util.appType
+import com.freeletics.gradle.plugin.FreeleticsMultiplatformPlugin
+import com.freeletics.gradle.util.booleanProperty
+import com.freeletics.gradle.util.freeleticsAndroidExtension
+import com.freeletics.gradle.util.freeleticsMultiplatformExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+public abstract class AppMultiplatformPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply(FreeleticsMultiplatformPlugin::class.java)
+
+        target.freeleticsMultiplatformExtension.addAndroidTarget(variantsToPublish = null)
+        target.freeleticsMultiplatformExtension.addJvmTarget()
+        if (target.booleanProperty("fgp.kotlin.iosTargets", false).get()) {
+            target.freeleticsMultiplatformExtension.addIosTargetsWithXcFramework(target.name, includeX64 = true)
+        }
+
+        target.freeleticsMultiplatformExtension.useAndroidLint()
+        target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
+
+        target.registerCheckDependencyRulesTasks(
+            allowedProjectTypes = listOf(ProjectType.APP),
+            allowedDependencyProjectTypes = listOfNotNull(
+                ProjectType.CORE_API,
+                ProjectType.CORE_IMPLEMENTATION,
+                ProjectType.CORE_TESTING,
+                ProjectType.DOMAIN_API,
+                ProjectType.DOMAIN_IMPLEMENTATION,
+                ProjectType.DOMAIN_TESTING,
+                ProjectType.FEATURE_IMPLEMENTATION,
+                ProjectType.FEATURE_NAV,
+            ),
+        )
+
+        target.applyPlatformConstraints(multiplatform = true)
+        target.disableMultiplatformLibraryTasks()
+    }
+}

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/CoreMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/CoreMultiplatformPlugin.kt
@@ -1,0 +1,40 @@
+package com.freeletics.gradle.monorepo.plugin
+
+import com.freeletics.gradle.monorepo.setup.applyPlatformConstraints
+import com.freeletics.gradle.monorepo.setup.disableMultiplatformLibraryTasks
+import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
+import com.freeletics.gradle.monorepo.util.ProjectType
+import com.freeletics.gradle.plugin.FreeleticsMultiplatformPlugin
+import com.freeletics.gradle.util.booleanProperty
+import com.freeletics.gradle.util.freeleticsMultiplatformExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+public abstract class CoreMultiplatformPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply(FreeleticsMultiplatformPlugin::class.java)
+
+        target.freeleticsMultiplatformExtension.addAndroidTarget(variantsToPublish = null)
+        target.freeleticsMultiplatformExtension.addJvmTarget()
+        if (target.booleanProperty("fgp.kotlin.iosTargets", false).get()) {
+            target.freeleticsMultiplatformExtension.addIosTargets(includeX64 = true)
+        }
+
+        target.freeleticsMultiplatformExtension.useAndroidLint()
+
+        target.registerCheckDependencyRulesTasks(
+            allowedProjectTypes = listOf(
+                ProjectType.CORE_API,
+                ProjectType.CORE_IMPLEMENTATION,
+                ProjectType.CORE_TESTING,
+            ),
+            allowedDependencyProjectTypes = listOf(
+                ProjectType.CORE_API,
+                ProjectType.CORE_TESTING,
+            ),
+        )
+
+        target.applyPlatformConstraints(multiplatform = true)
+        target.disableMultiplatformLibraryTasks()
+    }
+}

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainMultiplatformPlugin.kt
@@ -1,0 +1,47 @@
+package com.freeletics.gradle.monorepo.plugin
+
+import com.freeletics.gradle.monorepo.setup.applyPlatformConstraints
+import com.freeletics.gradle.monorepo.setup.disableMultiplatformLibraryTasks
+import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
+import com.freeletics.gradle.monorepo.util.ProjectType
+import com.freeletics.gradle.monorepo.util.appType
+import com.freeletics.gradle.monorepo.util.projectType
+import com.freeletics.gradle.plugin.FreeleticsMultiplatformPlugin
+import com.freeletics.gradle.util.booleanProperty
+import com.freeletics.gradle.util.freeleticsAndroidExtension
+import com.freeletics.gradle.util.freeleticsMultiplatformExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+public abstract class DomainMultiplatformPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply(FreeleticsMultiplatformPlugin::class.java)
+
+        target.freeleticsMultiplatformExtension.addAndroidTarget(variantsToPublish = null)
+        target.freeleticsMultiplatformExtension.addJvmTarget()
+        if (target.booleanProperty("fgp.kotlin.iosTargets", false).get()) {
+            target.freeleticsMultiplatformExtension.addIosTargets(includeX64 = true)
+        }
+
+        target.freeleticsMultiplatformExtension.useAndroidLint()
+        target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
+
+        target.registerCheckDependencyRulesTasks(
+            allowedProjectTypes = listOf(
+                ProjectType.DOMAIN_API,
+                ProjectType.DOMAIN_IMPLEMENTATION,
+                ProjectType.DOMAIN_TESTING,
+            ),
+            allowedDependencyProjectTypes = listOfNotNull(
+                ProjectType.CORE_API,
+                ProjectType.CORE_TESTING,
+                ProjectType.DOMAIN_API,
+                ProjectType.DOMAIN_TESTING,
+                if (target.projectType() == ProjectType.DOMAIN_IMPLEMENTATION) ProjectType.FEATURE_NAV else null,
+            ),
+        )
+
+        target.applyPlatformConstraints(multiplatform = true)
+        target.disableMultiplatformLibraryTasks()
+    }
+}

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeatureAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeatureAndroidPlugin.kt
@@ -11,7 +11,7 @@ import com.freeletics.gradle.util.freeleticsExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-public abstract class FeaturePlugin : Plugin<Project> {
+public abstract class FeatureAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsAndroidPlugin::class.java)
 

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeatureMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeatureMultiplatformPlugin.kt
@@ -1,0 +1,45 @@
+package com.freeletics.gradle.monorepo.plugin
+
+import com.freeletics.gradle.monorepo.setup.applyPlatformConstraints
+import com.freeletics.gradle.monorepo.setup.disableMultiplatformLibraryTasks
+import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
+import com.freeletics.gradle.monorepo.util.ProjectType
+import com.freeletics.gradle.monorepo.util.appType
+import com.freeletics.gradle.plugin.FreeleticsMultiplatformPlugin
+import com.freeletics.gradle.util.booleanProperty
+import com.freeletics.gradle.util.freeleticsAndroidExtension
+import com.freeletics.gradle.util.freeleticsExtension
+import com.freeletics.gradle.util.freeleticsMultiplatformExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+public abstract class FeatureMultiplatformPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply(FreeleticsMultiplatformPlugin::class.java)
+
+        target.freeleticsExtension.useCompose()
+
+        target.freeleticsMultiplatformExtension.addAndroidTarget(variantsToPublish = null)
+        target.freeleticsMultiplatformExtension.addJvmTarget()
+        if (target.booleanProperty("fgp.kotlin.iosTargets", false).get()) {
+            target.freeleticsMultiplatformExtension.addIosTargets(includeX64 = true)
+        }
+
+        target.freeleticsMultiplatformExtension.useAndroidLint()
+        target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
+
+        target.registerCheckDependencyRulesTasks(
+            allowedProjectTypes = listOf(ProjectType.FEATURE_IMPLEMENTATION),
+            allowedDependencyProjectTypes = listOfNotNull(
+                ProjectType.CORE_API,
+                ProjectType.CORE_TESTING,
+                ProjectType.DOMAIN_API,
+                ProjectType.DOMAIN_TESTING,
+                ProjectType.FEATURE_NAV,
+            ),
+        )
+
+        target.applyPlatformConstraints(multiplatform = true)
+        target.disableMultiplatformLibraryTasks()
+    }
+}

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/NavAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/NavAndroidPlugin.kt
@@ -10,7 +10,7 @@ import com.freeletics.gradle.util.freeleticsAndroidExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-public abstract class NavPlugin : Plugin<Project> {
+public abstract class NavAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsAndroidPlugin::class.java)
 

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/NavMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/NavMultiplatformPlugin.kt
@@ -1,0 +1,44 @@
+package com.freeletics.gradle.monorepo.plugin
+
+import com.freeletics.gradle.monorepo.setup.applyPlatformConstraints
+import com.freeletics.gradle.monorepo.setup.disableMultiplatformLibraryTasks
+import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
+import com.freeletics.gradle.monorepo.util.ProjectType
+import com.freeletics.gradle.monorepo.util.appType
+import com.freeletics.gradle.plugin.FreeleticsMultiplatformPlugin
+import com.freeletics.gradle.util.booleanProperty
+import com.freeletics.gradle.util.freeleticsAndroidExtension
+import com.freeletics.gradle.util.freeleticsExtension
+import com.freeletics.gradle.util.freeleticsMultiplatformExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+public abstract class NavMultiplatformPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        target.plugins.apply(FreeleticsMultiplatformPlugin::class.java)
+
+        target.freeleticsExtension.useSerialization()
+
+        target.freeleticsMultiplatformExtension.addAndroidTarget(variantsToPublish = null)
+        target.freeleticsMultiplatformExtension.addJvmTarget()
+        if (target.booleanProperty("fgp.kotlin.iosTargets", false).get()) {
+            target.freeleticsMultiplatformExtension.addIosTargets(includeX64 = true)
+        }
+
+        target.freeleticsAndroidExtension.minSdkVersion(target.appType()?.minSdkVersion(target))
+        target.freeleticsMultiplatformExtension.useAndroidLint()
+
+        target.registerCheckDependencyRulesTasks(
+            allowedProjectTypes = listOf(ProjectType.FEATURE_NAV),
+            allowedDependencyProjectTypes = listOf(
+                ProjectType.CORE_API,
+                ProjectType.CORE_TESTING,
+                ProjectType.DOMAIN_API,
+                ProjectType.DOMAIN_TESTING,
+            ),
+        )
+
+        target.applyPlatformConstraints(multiplatform = true)
+        target.disableMultiplatformLibraryTasks()
+    }
+}

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/DisableTasks.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/DisableTasks.kt
@@ -8,6 +8,10 @@ internal fun Project.disableAndroidApplicationTasks() {
     disableAndroidTasks(androidAppLintTasksToDisableExceptOneVariant, "debug")
 }
 
+internal fun Project.disableMultiplatformApplicationTasks() {
+    // TODO lint tasks
+}
+
 internal fun Project.disableAndroidLibraryTasks() {
     disableAndroidTasks(androidLibraryTasksToDisable)
     disableAndroidTasks(androidLibraryLintTasksToDisable)
@@ -17,6 +21,11 @@ internal fun Project.disableAndroidLibraryTasks() {
 internal fun Project.disableKotlinLibraryTasks() {
     disableTasks(listOf("assemble"))
     disableTasks(lintTasksToDisableJvm)
+}
+
+internal fun Project.disableMultiplatformLibraryTasks() {
+    disableTasks(listOf("assemble"))
+    // TODO lint tasks
 }
 
 private fun Project.disableAndroidTasks(names: List<String>, variantToKeep: String = "") {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/Platform.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/setup/Platform.kt
@@ -2,17 +2,26 @@ package com.freeletics.gradle.monorepo.setup
 
 import org.gradle.api.Project
 
-internal fun Project.applyPlatformConstraints() {
+internal fun Project.applyPlatformConstraints(multiplatform: Boolean = false) {
     val platformDependency = dependencies.enforcedPlatform(rootProject)
     configurations.configureEach { config ->
-        if (isPlatformConfigurationName(config.name)) {
+        if (isPlatformConfigurationName(config.name, multiplatform)) {
             config.dependencies.add(platformDependency)
         }
     }
 }
 
 // adapted from https://github.com/ZacSweers/CatchUp/blob/347db46d82497990ff10c441ecc75c0c9eedf7c4/buildSrc/src/main/kotlin/dev/zacsweers/catchup/gradle/CatchUpPlugin.kt#L68-L80
-private fun isPlatformConfigurationName(name: String): Boolean {
+private fun isPlatformConfigurationName(name: String, multiplatform: Boolean): Boolean {
+    // TODO: KT-61653 KMP fails on androidTest*Api dependencies
+    if (multiplatform) {
+        MULTIPLATFORM_API_IGNORE_CONFIGURATION.forEach {
+            if (name.contains(it, ignoreCase = true) && name.endsWith("api", ignoreCase = true)) {
+                return false
+            }
+        }
+    }
+
     // Try trimming the flavor by just matching the prefix
     PLATFORM_CONFIGURATION_PREFIX.forEach { platformConfig ->
         if (name.startsWith(platformConfig, ignoreCase = true)) {
@@ -45,4 +54,12 @@ private val PLATFORM_CONFIGURATION_SUFFIX = setOf(
     "androidTestUtil",
     "lintChecks",
     "lintRelease",
+)
+
+private val MULTIPLATFORM_API_IGNORE_CONFIGURATION = setOf(
+    "androidTest",
+    "androidUnitTest",
+    "androidDebugUnitTest",
+    "androidReleaseUnitTest",
+    "androidInstrumentedTest",
 )


### PR DESCRIPTION
Adds multiplatform variants of all monorepo plugins. For core/domain/feature/nav these are just copies with small kmp specific adjustments. For the app level there is a general `com.freeletics.gradle.app.multiplatform` which is still a library. The idea is that the Android and desktop apps are separate modules which then depend on that. Why separate app modules? For iOS the app module is an xcode project and the "app library" produces the framework that the xcode project uses. For Android you could currently use the `com.android.application` plugin on the KMP module however that's not possible anymore with the coming [`com.android.kotlin.multiplatform.library`](https://developer.android.com/kotlin/multiplatform/plugin) plugin, so then we would need Android to be separate too (also means we don't need to have shared code between "kmp android app" and "android only app", since they are just separate now). For desktop it's currently not needed in any way, there it's just consistency. 

There's still a TODO for disabling not needed lint tasks and desktop versioning but those are currently not important and can be ignored for during explorations.