### PR TITLE
disable GradleDependency

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidLintSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidLintSetup.kt
@@ -30,6 +30,7 @@ internal fun Lint.configure(project: Project) {
     textOutput = project.reportsFile("lint-result.txt").get().asFile
 
     disable += "NewerVersionAvailable"
+    disable += "GradleDependency"
 
     project.dependencies.addMaybe("lintChecks", project.getBundleOrNull("default-lint"))
 }


### PR DESCRIPTION
Check randomly fails when new versions are being released and we have renovate to cover this.