### PR TITLE
fix defaultPackageName for non monorepo projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+## 0.30.2 *(2025-08-04)*
+
+- Fix default package name logic for the non monorepo plugins.
+
+
 ## 0.30.1 *(2025-08-01)*
 
 - Add missing `com.freeletics.gradle.core.multiplatform` and `com.freeletics.gradle.core.multiplatform` plugin ids.

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/util/ProjectType.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/util/ProjectType.kt
@@ -26,6 +26,10 @@ internal fun Project.projectType(): ProjectType {
 }
 
 internal fun String.toProjectType(): ProjectType {
+    return toProjectTypeOrNull() ?: throw IllegalStateException("Unknown project type $this")
+}
+
+internal fun String.toProjectTypeOrNull(): ProjectType? {
     return when {
         startsWith(":app:") -> ProjectType.APP
         startsWith(":core:") && endsWith(":api") -> ProjectType.CORE_API
@@ -37,6 +41,6 @@ internal fun String.toProjectType(): ProjectType {
         startsWith(":feature") && endsWith(":implementation") -> ProjectType.FEATURE_IMPLEMENTATION
         startsWith(":feature") && endsWith(":nav") -> ProjectType.FEATURE_NAV
         startsWith(":legacy-freeletics:") -> ProjectType.LEGACY
-        else -> throw IllegalStateException("Unknown project type $this")
+        else -> null
     }
 }

--- a/plugins/src/test/kotlin/com/freeletics/gradle/util/PackageNameTest.kt
+++ b/plugins/src/test/kotlin/com/freeletics/gradle/util/PackageNameTest.kt
@@ -261,4 +261,28 @@ class PackageNameTest {
         assertThat(defaultPackageName(":app:productName-android", "com.product"))
             .isEqualTo("com.product.android")
     }
+
+    @Test
+    fun `defaultPackageName for non monorepo project`() {
+        assertThat(defaultPackageName(":navigation", "com.project"))
+            .isEqualTo("com.project.navigation")
+    }
+
+    @Test
+    fun `defaultPackageName for nested non monorepo project`() {
+        assertThat(defaultPackageName(":navigation:testing", "com.project"))
+            .isEqualTo("com.project.navigation.testing")
+    }
+
+    @Test
+    fun `defaultPackageName for non monorepo project with dash`() {
+        assertThat(defaultPackageName(":navigation-testing", "com.project"))
+            .isEqualTo("com.project.navigation.testing")
+    }
+
+    @Test
+    fun `defaultPackageName for non monorepo project with camel case`() {
+        assertThat(defaultPackageName(":navigationTesting", "com.project"))
+            .isEqualTo("com.project.navigationtesting")
+    }
 }


### PR DESCRIPTION
Fixes that `toProjectType()` only works for the monorepo module structure.