### PR TITLE
use new Android KMP library plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,7 +40,8 @@ kotlin-gradle-atomicfu = { module = "org.jetbrains.kotlin:atomicfu", version.ref
 kotlin-gradle-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 javax-inject = { module = "javax.inject:javax.inject", version = "1" }
 
-android-gradle = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "android-gradle" }
+android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle" }
 ksp-gradle = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin",  version.ref = "ksp" }
 metro-gradle = { module = "dev.zacsweers.metro:gradle-plugin", version = "0.7.4" }
 poko-gradle = { module = "dev.drewhamilton.poko:poko-gradle-plugin", version = "0.20.1" }

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -4,13 +4,16 @@ plugins {
 }
 
 dependencies {
-    api(libs.kotlin.gradle)
     api(libs.kotlin.gradle.api)
     api(libs.javax.inject)
+    implementation(libs.android.gradle.api)
     implementation(libs.annotations)
-    implementation(libs.android.gradle)
-    compileOnly(libs.kotlin.gradle.annotations)
     implementation(libs.kotlin.native.utils)
+    implementation(projects.codegen)
+    compileOnly(libs.kotlin.gradle.annotations)
+
+    // plugins needed at both compile time for configuration and at runtime as default version
+    api(libs.kotlin.gradle)
     implementation(libs.ksp.gradle)
     implementation(libs.sqldelight.gradle)
     implementation(libs.compose.gradle)
@@ -18,8 +21,12 @@ dependencies {
     implementation(libs.publish.gradle)
     implementation(libs.licensee.gradle)
     implementation(libs.crashlytics.gradle)
-    implementation(projects.codegen)
+
+    // already brought in by settings plugin
     compileOnly(libs.develocity.gradle)
+
+    // add to runtime so that consumers can get a default version
+    runtimeOnly(libs.android.gradle)
     runtimeOnly(libs.kotlin.gradle.compose)
     runtimeOnly(libs.kotlin.gradle.atomicfu)
     runtimeOnly(libs.kotlin.gradle.serialization)

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidAppPlugin.kt
@@ -1,5 +1,8 @@
 package com.freeletics.gradle.plugin
 
+import com.freeletics.gradle.util.androidApp
+import com.freeletics.gradle.util.getVersion
+import kotlin.text.toInt
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
@@ -7,5 +10,13 @@ public abstract class FreeleticsAndroidAppPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply("com.android.application")
         target.plugins.apply(FreeleticsAndroidPlugin::class.java)
+
+        target.androidSetup()
+    }
+
+    private fun Project.androidSetup() {
+        androidApp {
+            defaultConfig.targetSdk = getVersion("android.target").toInt()
+        }
     }
 }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -95,7 +95,7 @@ public abstract class FreeleticsAndroidExtension(private val project: Project) {
     }
 }
 
-private class RoomSchemaArgProvider(
+internal class RoomSchemaArgProvider(
     @get:InputDirectory
     @get:PathSensitive(PathSensitivity.RELATIVE)
     val schemaDir: File,

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidPlugin.kt
@@ -1,6 +1,5 @@
 package com.freeletics.gradle.plugin
 
-import com.android.build.api.dsl.ApplicationDefaultConfig
 import com.android.build.api.variant.HasAndroidTestBuilder
 import com.android.build.api.variant.HasUnitTestBuilder
 import com.freeletics.gradle.setup.configure
@@ -27,16 +26,13 @@ public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
         if (!target.plugins.hasPlugin("com.android.application")) {
             target.plugins.apply("com.android.library")
         }
-        if (!target.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {
-            target.plugins.apply("org.jetbrains.kotlin.android")
-        }
+        target.plugins.apply("org.jetbrains.kotlin.android")
         target.plugins.apply(FreeleticsBasePlugin::class.java)
 
         target.freeleticsExtension.extensions.create("android", FreeleticsAndroidExtension::class.java)
 
         target.androidSetup()
         target.addDefaultAndroidDependencies()
-        target.configureLint()
         target.disableReleaseUnitTests()
         target.disableAndroidTests()
     }
@@ -53,9 +49,6 @@ public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
 
             compileSdk = getVersion("android.compile").toInt()
             defaultConfig.minSdk = getVersion("android.min").toInt()
-            (defaultConfig as? ApplicationDefaultConfig)?.let {
-                it.targetSdk = getVersion("android.target").toInt()
-            }
 
             // default all features to false, they will be enabled through FreeleticsAndroidExtension
             androidResources.enable = false
@@ -74,6 +67,8 @@ public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
                 sourceCompatibility = javaTargetVersion
                 targetCompatibility = javaTargetVersion
             }
+
+            lint.configure(project)
         }
 
         dependencies.addMaybe("coreLibraryDesugaring", desugarLibrary)
@@ -87,12 +82,6 @@ public abstract class FreeleticsAndroidPlugin : Plugin<Project> {
         val compileBundle = getBundleOrNull("default-android-compile")
         if (compileBundle != null) {
             addCompileOnlyDependency(compileBundle, setOf(KotlinPlatformType.androidJvm))
-        }
-    }
-
-    private fun Project.configureLint() {
-        android {
-            lint.configure(project)
         }
     }
 

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformAndroidExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformAndroidExtension.kt
@@ -1,0 +1,47 @@
+package com.freeletics.gradle.plugin
+
+import com.freeletics.gradle.setup.basicArgument
+import com.freeletics.gradle.setup.configurePaparazzi
+import com.freeletics.gradle.setup.configureProcessing
+import com.freeletics.gradle.util.addApiDependency
+import com.freeletics.gradle.util.addKspDependency
+import com.freeletics.gradle.util.androidMultiplatform
+import com.freeletics.gradle.util.getDependency
+import java.io.File
+import org.gradle.api.Project
+
+public abstract class FreeleticsMultiplatformAndroidExtension(private val project: Project) {
+    public fun useRoom(schemaLocation: String? = null) {
+        val processingArguments = buildList {
+            add(basicArgument("room.generateKotlin", "true"))
+            schemaLocation?.let {
+                add(RoomSchemaArgProvider(schemaDir = File(project.projectDir, schemaLocation)))
+            }
+        }
+
+        project.configureProcessing(processingArguments)
+        project.addApiDependency(project.getDependency("androidx-room-runtime"))
+        project.addKspDependency(project.getDependency("androidx-room-compiler"))
+    }
+
+    public fun usePaparazzi() {
+        project.configurePaparazzi()
+    }
+
+    public fun enableParcelize() {
+        project.plugins.apply("org.jetbrains.kotlin.plugin.parcelize")
+    }
+
+    public fun enableAndroidResources() {
+        project.androidMultiplatform {
+            androidResources.enable = true
+        }
+    }
+
+    @Suppress("UnstableApiUsage")
+    public fun consumerProguardFiles(vararg files: String) {
+        project.androidMultiplatform {
+            optimization.consumerKeepRules.files(*files)
+        }
+    }
+}

--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidTargetSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidTargetSetup.kt
@@ -1,0 +1,57 @@
+package com.freeletics.gradle.setup
+
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryTarget
+import com.freeletics.gradle.plugin.FreeleticsMultiplatformAndroidExtension
+import com.freeletics.gradle.util.addCompileOnlyDependency
+import com.freeletics.gradle.util.addImplementationDependency
+import com.freeletics.gradle.util.addMaybe
+import com.freeletics.gradle.util.defaultPackageName
+import com.freeletics.gradle.util.freeleticsExtension
+import com.freeletics.gradle.util.getBundleOrNull
+import com.freeletics.gradle.util.getDependencyOrNull
+import com.freeletics.gradle.util.getVersion
+import com.freeletics.gradle.util.getVersionOrNull
+import kotlin.text.toInt
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
+
+internal fun KotlinMultiplatformAndroidLibraryTarget.setupAndroidTarget(
+    target: Project,
+    configure: FreeleticsMultiplatformAndroidExtension.() -> Unit,
+) {
+    namespace = target.defaultPackageName()
+
+    val buildTools = target.getVersionOrNull("android.buildTools")
+    if (buildTools != null) {
+        buildToolsVersion = buildTools
+    }
+
+    compileSdk = target.getVersion("android.compile").toInt()
+    minSdk = target.getVersion("android.min").toInt()
+
+    // default all features to false, they will be enabled through FreeleticsAndroidExtension
+    androidResources.enable = false
+
+    val desugarLibrary = target.getDependencyOrNull("android.desugarjdklibs")
+    enableCoreLibraryDesugaring = desugarLibrary != null
+    target.dependencies.addMaybe("coreLibraryDesugaring", desugarLibrary)
+
+    lint.configure(target)
+
+    // enable tests
+    withHostTestBuilder {}.configure {}
+
+    // add default dependencies
+    val bundle = target.getBundleOrNull("default-android")
+    if (bundle != null) {
+        target.addImplementationDependency(bundle, setOf(KotlinPlatformType.androidJvm))
+    }
+    val compileBundle = target.getBundleOrNull("default-android-compile")
+    if (compileBundle != null) {
+        target.addCompileOnlyDependency(compileBundle, setOf(KotlinPlatformType.androidJvm))
+    }
+
+    project.freeleticsExtension.extensions
+        .create("android", FreeleticsMultiplatformAndroidExtension::class.java)
+        .configure()
+}

--- a/plugins/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/util/Extensions.kt
@@ -2,6 +2,7 @@ package com.freeletics.gradle.util
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
@@ -9,6 +10,7 @@ import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.freeletics.gradle.plugin.FreeleticsAndroidExtension
 import com.freeletics.gradle.plugin.FreeleticsBaseExtension
 import com.freeletics.gradle.plugin.FreeleticsMultiplatformExtension
+import com.gradle.scan.agent.serialization.scan.serializer.kryo.it
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.jetbrains.kotlin.gradle.dsl.HasConfigurableKotlinCompilerOptions
@@ -65,6 +67,14 @@ internal fun Project.android(action: CommonExtension<*, *, *, *, *, *>.() -> Uni
 
 internal fun Project.androidLibrary(action: LibraryExtension.() -> Unit) {
     extensions.configure(LibraryExtension::class.java) {
+        it.action()
+    }
+}
+
+internal fun Project.androidMultiplatform(action: KotlinMultiplatformAndroidLibraryExtension.() -> Unit) {
+    extensions.getByType(
+        KotlinMultiplatformExtension::class.java,
+    ).extensions.configure(KotlinMultiplatformAndroidLibraryExtension::class.java) {
         it.action()
     }
 }


### PR DESCRIPTION
See https://developer.android.com/kotlin/multiplatform/plugin.

There is a new plugin that is used to add Android targets to KMP projects. This is more targeted and much slimmer than the approach with the regular Android library plugin. In AGP 9.0 this becomes the default unless opting out of some new behaviors (that will eventually be removed). 

One downside is that the DSL of the new plugin does not share an interface with the other Android plugins, so the setup needs to duplicate some configuration.