### PR TITLE
add extension method to enable compose resources

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/util/AppType.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/util/AppType.kt
@@ -17,7 +17,7 @@ internal fun Project.appType(): AppType? {
 
 internal fun String.toAppType(): AppType? {
     if (startsWith(":app:")) {
-        return AppType(substringAfter(":app:"))
+        return AppType(substringAfter(":app:").substringBefore("-"))
     }
     val firstPathElement = split(":")[1]
     if (firstPathElement.contains("-")) {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -1,12 +1,18 @@
 package com.freeletics.gradle.plugin
 
 import com.freeletics.gradle.setup.configureStandaloneLint
+import com.freeletics.gradle.util.addImplementationDependency
+import com.freeletics.gradle.util.defaultPackageName
 import com.freeletics.gradle.util.kotlinMultiplatform
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.tasks.bundling.Zip
+import org.jetbrains.compose.ComposeExtension
+import org.jetbrains.compose.ComposePlugin
+import org.jetbrains.compose.compose
+import org.jetbrains.compose.resources.ResourcesExtension
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.plugin.mpp.Framework
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
@@ -182,6 +188,19 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
                 androidNativeX64()
             }
         }
+    }
+
+    public fun useComposeResources() {
+        project.plugins.apply("org.jetbrains.compose")
+
+        project.extensions.configure(ComposeExtension::class.java) { compose ->
+            compose.extensions.configure(ResourcesExtension::class.java) {
+                it.generateResClass = ResourcesExtension.ResourceClassGeneration.Always
+                it.packageOfResClass = project.defaultPackageName()
+            }
+        }
+
+        project.addImplementationDependency(ComposePlugin.CommonComponentsDependencies.resources)
     }
 
     public fun useSkie() {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/util/Kmp.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/util/Kmp.kt
@@ -53,6 +53,14 @@ internal fun Project.addImplementationDependency(
     addImplementationDependency(dependency as Any?, limitToTargets)
 }
 
+@JvmName("addImplementationDependencyString")
+internal fun Project.addImplementationDependency(
+    dependency: String,
+    limitToTargets: Set<KotlinPlatformType>? = null,
+) {
+    addImplementationDependency(dependency as Any?, limitToTargets)
+}
+
 private fun Project.addImplementationDependency(
     dependency: Any?,
     limitToTargets: Set<KotlinPlatformType>? = null,


### PR DESCRIPTION
Allows enabling the compose multiplatform resource mechanism for a module and configures the package name of the generated resource file to be our default package name.