### PR TITLE
update common proguard rules

### DIFF
--- a/minify-common/src/main/resources/META-INF/proguard/common.pro
+++ b/minify-common/src/main/resources/META-INF/proguard/common.pro
@@ -1,10 +1,7 @@
-# https://cs.android.com/android-studio/platform/tools/base/+/refs/tags/studio-2021.1.1:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-optimizations.txt;l=8
+# https://cs.android.com/android-studio/platform/tools/base/+/d732d3188323ed66e1248d06f49bd13de87d0684:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-optimizations.txt
 -allowaccessmodification
 
-# https://cs.android.com/android-studio/platform/tools/base/+/refs/tags/studio-2021.1.1:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt;l=1
--dontusemixedcaseclassnames
-
-# https://cs.android.com/android-studio/platform/tools/base/+/refs/tags/studio-2021.1.1:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt;l=5-12
+# https://cs.android.com/android-studio/platform/tools/base/+/710383a66f0637acc9a091f826d45ac7bb6d79cf:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt;l=1-8
 # Preserve some attributes that may be required for reflection.
 -keepattributes AnnotationDefault,
                 EnclosingMethod,
@@ -14,14 +11,20 @@
                 RuntimeVisibleTypeAnnotations,
                 Signature
 
-# https://cs.android.com/android-studio/platform/tools/base/+/refs/tags/studio-2021.1.1:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt;l=37-41
+# https://cs.android.com/android-studio/platform/tools/base/+/710383a66f0637acc9a091f826d45ac7bb6d79cf:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt;l=17-20
+# For native methods, see https://www.guardsquare.com/manual/configuration/examples#native
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
+# https://cs.android.com/android-studio/platform/tools/base/+/710383a66f0637acc9a091f826d45ac7bb6d79cf:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt;l=33-37
 # For enumeration classes, see http://proguard.sourceforge.net/manual/examples.html#enumerations
 -keepclassmembers enum * {
     public static **[] values();
     public static ** valueOf(java.lang.String);
 }
 
-# https://cs.android.com/android-studio/platform/tools/base/+/refs/tags/studio-2021.1.1:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt;l=43-45
+# https://cs.android.com/android-studio/platform/tools/base/+/710383a66f0637acc9a091f826d45ac7bb6d79cf:build-system/gradle-core/src/main/resources/com/android/build/gradle/proguard-common.txt;l=39-41
 -keepclassmembers class * implements android.os.Parcelable {
     public static final ** CREATOR;
 }


### PR DESCRIPTION
Primarily adds the default keep rule for native methods. Firebase is using the multi process AndroidX DataStore which has some native code which crashes without the rule. I used this as a chance to fully go through the current default proguard file again and update the links based on the latest version.