### PR TITLE
embed editorconfig defaults

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,5 +52,9 @@ dependencyAnalysis {
         bundle("zxing") {
             includeGroup("com.google.zxing")
         }
+        bundle("ktlint") {
+            includeGroup("com.pinterest.ktlint")
+            includeGroup("org.ec4j.core")
+        }
     }
 }

--- a/scripts-formatting/src/main/kotlin/com/freeletics/gradle/scripts/FindFiles.kt
+++ b/scripts-formatting/src/main/kotlin/com/freeletics/gradle/scripts/FindFiles.kt
@@ -4,6 +4,7 @@ import java.nio.file.FileSystems
 import java.nio.file.FileVisitResult
 import java.nio.file.Path
 import java.nio.file.PathMatcher
+import kotlin.io.path.absolute
 import kotlin.io.path.isHidden
 import kotlin.io.path.name
 import kotlin.io.path.visitFileTree
@@ -12,6 +13,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
 
 internal val kotlinMatcher = FileSystems.getDefault().getPathMatcher("glob:**/*.{kt,kts}")
 
@@ -21,7 +23,10 @@ internal fun filesToFormat(
     matcher: PathMatcher,
 ): Flow<Path> {
     if (files != null) {
-        return files.asFlow().filter { matcher.matches(it) }
+        return files.asFlow()
+            .filter { matcher.matches(it) }
+            // needed for editorconfig to be found
+            .map { it.absolute() }
     }
 
     return channelFlow {

--- a/scripts-formatting/src/main/kotlin/com/freeletics/gradle/scripts/KtLintCli.kt
+++ b/scripts-formatting/src/main/kotlin/com/freeletics/gradle/scripts/KtLintCli.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.runBlocking
 public class KtLintCli : CliktCommand() {
     private val rootDirectory: Path by option(
         "--root",
-        help = "The root directory of the project, used as starting point to search files and to find editorconfig. " +
+        help = "The root directory of the project, used as starting point to search files. " +
             "Uses current directory if not specified",
     ).path().default(Paths.get(".").absolute())
 
@@ -46,7 +46,7 @@ public class KtLintCli : CliktCommand() {
             return@runBlocking
         }
 
-        val formatter = KtLintFormatter(rootDirectory.resolve(".editorconfig"))
+        val formatter = KtLintFormatter()
 
         var count = 0
         var hadChanges = false

--- a/scripts-formatting/src/main/kotlin/com/freeletics/gradle/scripts/KtLintFormatter.kt
+++ b/scripts-formatting/src/main/kotlin/com/freeletics/gradle/scripts/KtLintFormatter.kt
@@ -9,16 +9,52 @@ import com.pinterest.ktlint.rule.engine.core.api.AutocorrectDecision
 import com.pinterest.ktlint.rule.engine.core.api.RuleId
 import com.pinterest.ktlint.ruleset.standard.StandardRuleSetProvider
 import java.nio.file.Path
+import java.nio.file.Paths
 import kotlin.io.path.writeText
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.channelFlow
+import org.ec4j.core.model.EditorConfig
+import org.ec4j.core.model.Glob
+import org.ec4j.core.model.Property
+import org.ec4j.core.model.Section
 
-internal class KtLintFormatter(
-    editorConfig: Path,
-) {
+internal class KtLintFormatter() {
+    private val editorConfigDefaults = EditorConfigDefaults(
+        EditorConfig
+            .builder()
+            .section(
+                Section
+                    .builder()
+                    .glob(Glob("*.{kt,kts}"))
+                    .properties(
+                        // allow test methods with back ticked names to be longer than the line limit
+                        Property
+                            .builder()
+                            .name("ktlint_ignore_back_ticked_identifier")
+                            .value("true"),
+                        // allow composable functions to be capitalized
+                        Property
+                            .builder()
+                            .name("ktlint_function_naming_ignore_when_annotated_with")
+                            .value("Composable"),
+                        // remove unused imports
+                        Property
+                            .builder()
+                            .name("ktlint_standard_no-unused-imports")
+                            .value("enabled"),
+                        // see https://github.com/pinterest/ktlint/issues/2138
+                        Property
+                            .builder()
+                            .name("ktlint_standard_annotation")
+                            .value("disabled"),
+                    ),
+            )
+            .build(),
+    )
+
     private val engine = KtLintRuleEngine(
         ruleProviders = StandardRuleSetProvider().getRuleProviders(),
-        editorConfigDefaults = EditorConfigDefaults.load(editorConfig, emptySet()),
+        editorConfigDefaults = editorConfigDefaults,
     )
 
     internal fun format(path: Path) = channelFlow {


### PR DESCRIPTION
Adds some default config values like enabling `no-unused-imports` again so that they don't need to be repeated across projects.