### PR TITLE
fix local mode for appium

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/AppiumPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/AppiumPlugin.kt
@@ -42,7 +42,7 @@ public abstract class AppiumPlugin : Plugin<Project> {
         val testClassesDir = layout.buildDirectory.dir("testClasses")
         return tasks.register("unzipTests", Copy::class.java) {
             if (localTestCases) {
-                it.dependsOn(tasks.getByPath(":testing:appium-tests:jar"))
+                it.dependsOn(tasks.getByPath(":testing:appium-tests:jvmJar"))
             }
             it.from(zipTree(testCases.singleFile))
             it.into(testClassesDir)


### PR DESCRIPTION
With the switch of the plugin from jvm to multiplatform the task name changed.