### PR TITLE
split compilerOptions

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -7,7 +7,7 @@ import com.freeletics.gradle.setup.setupOssPublishing
 import com.freeletics.gradle.setup.setupSqlDelight
 import com.freeletics.gradle.util.addApiDependency
 import com.freeletics.gradle.util.addKspDependency
-import com.freeletics.gradle.util.compilerOptions
+import com.freeletics.gradle.util.compilerOptionsCommon
 import com.freeletics.gradle.util.getDependency
 import com.freeletics.gradle.util.kotlin
 import org.gradle.api.Project
@@ -23,7 +23,7 @@ public abstract class FreeleticsBaseExtension(private val project: Project) : Ex
 
     public fun optIn(vararg classes: String) {
         project.kotlin {
-            compilerOptions {
+            compilerOptionsCommon {
                 optIn.addAll(*classes)
             }
         }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsGradlePluginPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsGradlePluginPlugin.kt
@@ -1,7 +1,7 @@
 package com.freeletics.gradle.plugin
 
 import com.freeletics.gradle.setup.configureStandaloneLint
-import com.freeletics.gradle.util.compilerOptions
+import com.freeletics.gradle.util.compilerOptionsJvm
 import com.freeletics.gradle.util.java
 import com.freeletics.gradle.util.javaTargetVersion
 import com.freeletics.gradle.util.kotlin
@@ -26,7 +26,7 @@ public abstract class FreeleticsGradlePluginPlugin : Plugin<Project> {
         }
 
         target.kotlin {
-            compilerOptions {
+            compilerOptionsJvm {
                 // https://docs.gradle.org/current/userguide/compatibility.html#kotlin
                 apiVersion.set(KotlinVersion.KOTLIN_2_2)
                 languageVersion.set(KotlinVersion.KOTLIN_2_2)

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformPlugin.kt
@@ -1,7 +1,7 @@
 package com.freeletics.gradle.plugin
 
 import com.freeletics.gradle.setup.configureStandaloneLint
-import com.freeletics.gradle.util.compilerOptions
+import com.freeletics.gradle.util.compilerOptionsCommon
 import com.freeletics.gradle.util.freeleticsExtension
 import com.freeletics.gradle.util.kotlin
 import com.freeletics.gradle.util.kotlinMultiplatform
@@ -21,7 +21,7 @@ public abstract class FreeleticsMultiplatformPlugin : Plugin<Project> {
         }
 
         target.kotlin {
-            compilerOptions {
+            compilerOptionsCommon {
                 freeCompilerArgs.add("-Xexpect-actual-classes")
             }
         }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/ComposeSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/ComposeSetup.kt
@@ -1,7 +1,7 @@
 package com.freeletics.gradle.setup
 
 import com.freeletics.gradle.util.booleanProperty
-import com.freeletics.gradle.util.compilerOptions
+import com.freeletics.gradle.util.compilerOptionsCommon
 import com.freeletics.gradle.util.kotlin
 import org.gradle.api.Project
 
@@ -16,7 +16,7 @@ internal fun Project.setupCompose() {
             .get()
 
         kotlin {
-            compilerOptions {
+            compilerOptionsCommon {
                 freeCompilerArgs.addAll(
                     "-P",
                     "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$metricsFolderAbsolutePath",
@@ -33,7 +33,7 @@ internal fun Project.setupCompose() {
             .get()
 
         kotlin {
-            compilerOptions {
+            compilerOptionsCommon {
                 freeCompilerArgs.addAll(
                     "-P",
                     "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$reportsFolderAbsolutePath",


### PR DESCRIPTION
Instead of applying `compilerOptions` implicitly to both the common source set and all targets, split the 2 declarations. Avoids some potential issues with the Android KMP plugin and avoids applying things multiple times.