### PR TITLE
don't enable parcelize by default

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/CoreAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/CoreAndroidPlugin.kt
@@ -6,15 +6,12 @@ import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.r
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.monorepo.util.projectType
 import com.freeletics.gradle.plugin.FreeleticsAndroidPlugin
-import com.freeletics.gradle.util.freeleticsAndroidExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 public abstract class CoreAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsAndroidPlugin::class.java)
-
-        target.freeleticsAndroidExtension.enableParcelize()
 
         target.registerCheckDependencyRulesTasks(
             allowedProjectTypes = listOf(

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/DomainAndroidPlugin.kt
@@ -6,15 +6,12 @@ import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.r
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.monorepo.util.projectType
 import com.freeletics.gradle.plugin.FreeleticsAndroidPlugin
-import com.freeletics.gradle.util.freeleticsAndroidExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 public abstract class DomainAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsAndroidPlugin::class.java)
-
-        target.freeleticsAndroidExtension.enableParcelize()
 
         target.registerCheckDependencyRulesTasks(
             allowedProjectTypes = listOf(

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeatureAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/FeatureAndroidPlugin.kt
@@ -6,7 +6,6 @@ import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.r
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.monorepo.util.projectType
 import com.freeletics.gradle.plugin.FreeleticsAndroidPlugin
-import com.freeletics.gradle.util.freeleticsAndroidExtension
 import com.freeletics.gradle.util.freeleticsExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -18,8 +17,6 @@ public abstract class FeatureAndroidPlugin : Plugin<Project> {
         val extension = target.freeleticsExtension.extensions.create("legacy", LegacyExtension::class.java)
 
         target.freeleticsExtension.useCompose()
-        target.freeleticsAndroidExtension.enableAndroidResources()
-        target.freeleticsAndroidExtension.enableParcelize()
 
         target.afterEvaluate {
             target.registerCheckDependencyRulesTasks(

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/LegacyAndroidPlugin.kt
@@ -5,16 +5,12 @@ import com.freeletics.gradle.monorepo.setup.disableAndroidLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.plugin.FreeleticsAndroidPlugin
-import com.freeletics.gradle.util.freeleticsAndroidExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 public abstract class LegacyAndroidPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         target.plugins.apply(FreeleticsAndroidPlugin::class.java)
-
-        target.freeleticsAndroidExtension.enableAndroidResources()
-        target.freeleticsAndroidExtension.enableParcelize()
 
         target.registerCheckDependencyRulesTasks(
             allowedProjectTypes = listOf(ProjectType.LEGACY),

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/NavAndroidPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/plugin/NavAndroidPlugin.kt
@@ -5,7 +5,6 @@ import com.freeletics.gradle.monorepo.setup.disableAndroidLibraryTasks
 import com.freeletics.gradle.monorepo.tasks.CheckDependencyRulesTask.Companion.registerCheckDependencyRulesTasks
 import com.freeletics.gradle.monorepo.util.ProjectType
 import com.freeletics.gradle.plugin.FreeleticsAndroidPlugin
-import com.freeletics.gradle.util.freeleticsAndroidExtension
 import com.freeletics.gradle.util.freeleticsExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -15,7 +14,6 @@ public abstract class NavAndroidPlugin : Plugin<Project> {
         target.plugins.apply(FreeleticsAndroidPlugin::class.java)
 
         target.freeleticsExtension.useSerialization()
-        target.freeleticsAndroidExtension.enableParcelize()
 
         target.registerCheckDependencyRulesTasks(
             allowedProjectTypes = listOf(ProjectType.FEATURE_NAV),


### PR DESCRIPTION
With the switch to kotlinx.serialization in Khonshu we don't use parcelize that much anymore and it doesn't make sense anymore to just enable it everywhere.