### PR TITLE
remove ViewBinding option

### DIFF
--- a/plugins/api/plugins.api
+++ b/plugins/api/plugins.api
@@ -222,7 +222,6 @@ public abstract class com/freeletics/gradle/plugin/FreeleticsAndroidExtension {
 	public final fun enableBuildConfig ()V
 	public final fun enableParcelize ()V
 	public final fun enableResValues ()V
-	public final fun enableViewBinding ()V
 	public final fun resValue (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun resValue (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun usePaparazzi ()V

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsAndroidExtension.kt
@@ -38,12 +38,6 @@ public abstract class FreeleticsAndroidExtension(private val project: Project) {
         project.plugins.apply("org.jetbrains.kotlin.plugin.parcelize")
     }
 
-    public fun enableViewBinding() {
-        project.android {
-            buildFeatures.viewBinding = true
-        }
-    }
-
     public fun enableAndroidResources() {
         project.android {
             androidResources.enable = true


### PR DESCRIPTION
With the migration to the new Android KMP plugin view binding is not supported anymore, this removes the old option to enable it.