### PR TITLE
switch to paparazzi fork and update KMP config

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ coroutines = "1.10.2"
 android-gradle = "8.13.1"
 ksp="2.3.2"
 sqldelight = "2.1.0"
-paparazzi = "1.3.5"
+paparazzi = "2.0.0-alpha02-fl01"
 licensee = "1.14.1"
 crashlytics-gradle = "3.0.6"
 dependency-analysis = "3.4.1"
@@ -49,7 +49,7 @@ kopy-gradle = { module = "com.javiersc.kotlin:kopy-gradle-plugin", version = "0.
 skie-gradle = { module = "co.touchlab.skie:gradle-plugin", version = "0.10.8" }
 compose-gradle = { module = "org.jetbrains.compose:compose-gradle-plugin", version = "1.9.3"}
 sqldelight-gradle = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight" }
-paparazzi-gradle = { module = "app.cash.paparazzi:paparazzi-gradle-plugin", version.ref = "paparazzi" }
+paparazzi-gradle = { module = "com.freeletics.fork.paparazzi:paparazzi-gradle-plugin", version.ref = "paparazzi" }
 
 licensee-gradle = { module = "app.cash.licensee:licensee-gradle-plugin", version.ref = "licensee" }
 crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle", version.ref = "crashlytics-gradle" }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/RootPlugin.kt
@@ -168,8 +168,8 @@ public abstract class RootPlugin : Plugin<Project> {
                 }
 
                 structure.bundle("paparazzi") {
-                    it.primary("app.cash.paparazzi:paparazzi")
-                    it.includeGroup("app.cash.paparazzi")
+                    it.primary("com.freeletics.fork.paparazzi:paparazzi")
+                    it.includeGroup("com.freeletics.fork")
                     it.includeGroup("com.android.tools.layoutlib")
                 }
             }

--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidTargetSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/AndroidTargetSetup.kt
@@ -38,7 +38,7 @@ internal fun KotlinMultiplatformAndroidLibraryTarget.setupAndroidTarget(
     lint.configure(target)
 
     // enable tests
-    withHostTestBuilder {}.configure {}
+    withHostTest {}
 
     // add default dependencies
     val bundle = target.getBundleOrNull("default-android")


### PR DESCRIPTION
For proper KMP compatibility we're using a self published version again. Additionally updates the setup to work for the Android KMP plugin.