### PR TITLE
exclude metadata by default for ksp dependencies

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBaseExtension.kt
@@ -53,10 +53,7 @@ public abstract class FreeleticsBaseExtension(private val project: Project) : Ex
         useMetro()
         project.configureProcessing()
         project.addApiDependency(project.getDependency("khonshu-codegen-runtime"))
-        project.addKspDependency(
-            project.getDependency("khonshu-codegen-compiler"),
-            excludeTargets = setOf("metadata"),
-        )
+        project.addKspDependency(project.getDependency("khonshu-codegen-compiler"))
         // TODO workaround for Gradle not being able to resolve this in the ksp config
         project.configurations.named("ksp").configure {
             it.exclude(mapOf("group" to "org.jetbrains.skiko", "module" to "skiko"))

--- a/plugins/src/main/kotlin/com/freeletics/gradle/util/Dependencies.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/util/Dependencies.kt
@@ -213,7 +213,7 @@ private fun Project.addTestRuntimeOnlyDependency(
 internal fun Project.addKspDependency(
     dependency: Provider<MinimalExternalModuleDependency>?,
     limitToTargets: Set<String>? = null,
-    excludeTargets: Set<String>? = null,
+    excludeTargets: Set<String>? = setOf("metadata"),
 ) {
     addDependency(
         dependency = dependency,


### PR DESCRIPTION
This will make it that ksp is applied to all targets instead of just the common/metadata one by default which is usually what we want.