### PR TITLE
use internal instead of input for git root directory

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeGitShaTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeGitShaTask.kt
@@ -9,10 +9,8 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.UntrackedTask
@@ -22,8 +20,7 @@ public abstract class ComputeGitShaTask : DefaultTask() {
     @get:Input
     public abstract val computeFromGit: Property<Boolean>
 
-    @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Internal
     public abstract val gitRootDirectory: RegularFileProperty
 
     @get:OutputFile

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeGitTimestampTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeGitTimestampTask.kt
@@ -9,10 +9,8 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.UntrackedTask
@@ -22,8 +20,7 @@ public abstract class ComputeGitTimestampTask : DefaultTask() {
     @get:Input
     public abstract val computeFromGit: Property<Boolean>
 
-    @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Internal
     public abstract val gitRootDirectory: RegularFileProperty
 
     @get:OutputFile

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionCodeTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionCodeTask.kt
@@ -9,10 +9,8 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.UntrackedTask
@@ -25,8 +23,7 @@ public abstract class ComputeVersionCodeTask : DefaultTask() {
     @get:Input
     public abstract val gitTagName: Property<String>
 
-    @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Internal
     public abstract val gitRootDirectory: RegularFileProperty
 
     @get:OutputFile

--- a/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionNameTask.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/monorepo/tasks/ComputeVersionNameTask.kt
@@ -8,10 +8,8 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.UntrackedTask
@@ -24,8 +22,7 @@ public abstract class ComputeVersionNameTask : DefaultTask() {
     @get:Input
     public abstract val gitTagName: Property<String>
 
-    @get:InputDirectory
-    @get:PathSensitive(PathSensitivity.RELATIVE)
+    @get:Internal
     public abstract val gitRootDirectory: RegularFileProperty
 
     @get:OutputFile


### PR DESCRIPTION
The git root directory is effectively the root project, so Gradle would want any task to be a dependency of these. These tasks are already marked as `@UntrackedTask` so the inputs don't really matter.