### PR TITLE
make iOS x64 target optional and off by default

### DIFF
--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -27,13 +27,14 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
             project.freeleticsMultiplatformExtension.addJvmTarget()
         }
         if (project.booleanProperty("fgp.kotlin.targets.ios", false).get()) {
+            val x64 = project.booleanProperty("fgp.kotlin.targets.ios.x64", false).get()
             if (xcFramework) {
                 project.freeleticsMultiplatformExtension.addIosTargetsWithXcFramework(
                     frameworkName = project.name,
-                    includeX64 = true,
+                    includeX64 = x64,
                 )
             } else {
-                project.freeleticsMultiplatformExtension.addIosTargets(includeX64 = true)
+                project.freeleticsMultiplatformExtension.addIosTargets(includeX64 = x64)
             }
         }
     }


### PR DESCRIPTION
The target is deprecated by Kotlin and AndroidX started removing support for it.