### PR TITLE
throw exception if slack webhook fails

### DIFF
--- a/scripts-slack/src/jvmMain/kotlin/com/freeletics/gradle/scripts/SlackMessageCli.kt
+++ b/scripts-slack/src/jvmMain/kotlin/com/freeletics/gradle/scripts/SlackMessageCli.kt
@@ -40,7 +40,7 @@ public abstract class SlackMessageCli(name: String? = null) : CliktCommand(name)
             .blocks(withBlocks(builder))
             .build()
         val response = slack.send(webHookUrl, payload)
-        check(response.code == 200) { "Slack webhook failed with ${response.code}: ${response.message}" }
+        check(response.code in 200..299) { "Slack webhook failed with ${response.code}: ${response.message}" }
     }
 
     override fun help(context: Context): String {

--- a/scripts-slack/src/jvmMain/kotlin/com/freeletics/gradle/scripts/SlackMessageCli.kt
+++ b/scripts-slack/src/jvmMain/kotlin/com/freeletics/gradle/scripts/SlackMessageCli.kt
@@ -27,7 +27,7 @@ public abstract class SlackMessageCli(name: String? = null) : CliktCommand(name)
             .text(message)
             .build()
         val response = slack.send(webHookUrl, payload)
-        check(response.code == 200) { "Slack webhook failed with ${response.code}: ${response.message}" }
+        check(response.code in 200..299) { "Slack webhook failed with ${response.code}: ${response.message}" }
     }
 
     /**

--- a/scripts-slack/src/jvmMain/kotlin/com/freeletics/gradle/scripts/SlackMessageCli.kt
+++ b/scripts-slack/src/jvmMain/kotlin/com/freeletics/gradle/scripts/SlackMessageCli.kt
@@ -26,7 +26,8 @@ public abstract class SlackMessageCli(name: String? = null) : CliktCommand(name)
         val payload = Payload.builder()
             .text(message)
             .build()
-        slack.send(webHookUrl, payload)
+        val response = slack.send(webHookUrl, payload)
+        check(response.code == 200) { "Slack webhook failed with ${response.code}: ${response.message}" }
     }
 
     /**
@@ -38,7 +39,8 @@ public abstract class SlackMessageCli(name: String? = null) : CliktCommand(name)
             .text(fallbackMessage)
             .blocks(withBlocks(builder))
             .build()
-        slack.send(webHookUrl, payload)
+        val response = slack.send(webHookUrl, payload)
+        check(response.code == 200) { "Slack webhook failed with ${response.code}: ${response.message}" }
     }
 
     override fun help(context: Context): String {


### PR DESCRIPTION
instead of swallowing potential HTTP errors, this makes the script throw an exception instead