### PR TITLE
remove iOSX64 completely

### DIFF
--- a/plugins/api/plugins.api
+++ b/plugins/api/plugins.api
@@ -245,12 +245,9 @@ public abstract class com/freeletics/gradle/plugin/FreeleticsMultiplatformExtens
 	public final fun addCommonTargets (Z)V
 	public static synthetic fun addCommonTargets$default (Lcom/freeletics/gradle/plugin/FreeleticsMultiplatformExtension;ZILjava/lang/Object;)V
 	public final fun addIosTargets ()V
-	public final fun addIosTargets (Z)V
-	public static synthetic fun addIosTargets$default (Lcom/freeletics/gradle/plugin/FreeleticsMultiplatformExtension;ZILjava/lang/Object;)V
 	public final fun addIosTargetsWithXcFramework (Ljava/lang/String;)V
-	public final fun addIosTargetsWithXcFramework (Ljava/lang/String;Z)V
-	public final fun addIosTargetsWithXcFramework (Ljava/lang/String;ZLkotlin/jvm/functions/Function2;)V
-	public static synthetic fun addIosTargetsWithXcFramework$default (Lcom/freeletics/gradle/plugin/FreeleticsMultiplatformExtension;Ljava/lang/String;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public final fun addIosTargetsWithXcFramework (Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
+	public static synthetic fun addIosTargetsWithXcFramework$default (Lcom/freeletics/gradle/plugin/FreeleticsMultiplatformExtension;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public final fun addJvmTarget ()V
 	public final fun useComposeResources ()V
 	public final fun useSkie ()V

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -55,9 +55,8 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
         }
     }
 
-    @JvmOverloads
-    public fun addIosTargets(includeX64: Boolean = false) {
-        addIosTargets(includeX64) {}
+    public fun addIosTargets() {
+        addIosTargets() {}
     }
 
     private fun addIosTargets(configure: KotlinNativeTarget.() -> Unit) {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -62,25 +62,21 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
         addIosTargets(includeX64) {}
     }
 
-    private fun addIosTargets(includeX64: Boolean, configure: KotlinNativeTarget.() -> Unit) {
+    private fun addIosTargets(configure: KotlinNativeTarget.() -> Unit) {
         project.kotlinMultiplatform {
             iosArm64(configure)
             iosSimulatorArm64(configure)
-            if (includeX64) {
-                iosX64(configure)
-            }
         }
     }
 
     @JvmOverloads
     public fun addIosTargetsWithXcFramework(
         frameworkName: String,
-        includeX64: Boolean = false,
         configure: KotlinNativeTarget.(Framework) -> Unit = {},
     ) {
         val xcFramework = XCFrameworkConfig(project, frameworkName)
 
-        addIosTargets(includeX64 = includeX64) {
+        addIosTargets {
             binaries.framework {
                 baseName = frameworkName
                 xcFramework.add(this)
@@ -117,7 +113,6 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
             linuxArm64()
 
             iosArm64()
-            iosX64()
             iosSimulatorArm64()
 
             macosArm64()

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -56,7 +56,7 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
     }
 
     public fun addIosTargets() {
-        addIosTargets() {}
+        addIosTargets {}
     }
 
     private fun addIosTargets(configure: KotlinNativeTarget.() -> Unit) {

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsMultiplatformExtension.kt
@@ -27,14 +27,12 @@ public abstract class FreeleticsMultiplatformExtension(private val project: Proj
             project.freeleticsMultiplatformExtension.addJvmTarget()
         }
         if (project.booleanProperty("fgp.kotlin.targets.ios", false).get()) {
-            val x64 = project.booleanProperty("fgp.kotlin.targets.ios.x64", false).get()
             if (xcFramework) {
                 project.freeleticsMultiplatformExtension.addIosTargetsWithXcFramework(
                     frameworkName = project.name,
-                    includeX64 = x64,
                 )
             } else {
-                project.freeleticsMultiplatformExtension.addIosTargets(includeX64 = x64)
+                project.freeleticsMultiplatformExtension.addIosTargets()
             }
         }
     }


### PR DESCRIPTION
The main part is removing it from the common targets so that flowredux builds with new AndroidX versions that drop support (https://github.com/freeletics/FlowRedux/pull/1012) but I think we can just remove it completely.