### PR TITLE
Update abi extension usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+## 0.37.1 *(2026-06-22)*
+- Verify `abiValidation` extension is registered before configuring it.
+
 ## 0.37.0 *(2026-05-18)*
 - Remove the iOSX64 target completely. It was already disabled by default since 0.36.7 and is now removed to support new AndroidX versions that have dropped iosX64 support.
 

--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/PublishSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/PublishSetup.kt
@@ -12,8 +12,6 @@ import org.gradle.api.publish.maven.MavenPom
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
 import org.gradle.api.tasks.bundling.Zip
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationExtension
 import org.jetbrains.kotlin.gradle.dsl.abi.AbiValidationMultiplatformExtension
 import org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation

--- a/plugins/src/main/kotlin/com/freeletics/gradle/setup/PublishSetup.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/setup/PublishSetup.kt
@@ -141,26 +141,25 @@ internal fun setupXcFrameworkPublishing(project: Project, frameworkName: String)
 @OptIn(ExperimentalAbiValidation::class)
 private fun Project.configureBinaryCompatibility() {
     kotlin {
-        when (this) {
-            is KotlinJvmProjectExtension -> extensions.configure<AbiValidationExtension>(
-                "abiValidation",
-            ) { validation ->
-                validation.enabled.set(true)
+        // Preparation for DSL changes in 2.4.0: https://youtrack.jetbrains.com/issue/KT-80685
+        when (val abiExtension = extensions.findByName("abiValidation")) {
+            is AbiValidationExtension -> abiExtension.apply {
+                enabled.set(true)
                 // TODO remove manual task dependency https://youtrack.jetbrains.com/issue/KT-80614
                 tasks.named("check").configure { task ->
-                    task.dependsOn(validation.legacyDump.legacyCheckTaskProvider)
+                    task.dependsOn(legacyDump.legacyCheckTaskProvider)
                 }
             }
-            is KotlinMultiplatformExtension -> extensions.configure<AbiValidationMultiplatformExtension>(
-                "abiValidation",
-            ) { validation ->
-                validation.enabled.set(true)
+
+            is AbiValidationMultiplatformExtension -> abiExtension.apply {
+                enabled.set(true)
                 // TODO remove manual task dependency https://youtrack.jetbrains.com/issue/KT-80614
                 tasks.named("check").configure { task ->
-                    task.dependsOn(validation.legacyDump.legacyCheckTaskProvider)
+                    task.dependsOn(legacyDump.legacyCheckTaskProvider)
                 }
             }
-            else -> throw IllegalStateException("Unsupported kotlin extension ${this::class}")
+
+            else -> throw IllegalStateException("Unsupported kotlin extension ${abiExtension?.javaClass}")
         }
     }
 }


### PR DESCRIPTION
Due to [DSL change](https://youtrack.jetbrains.com/issue/KT-80685) in `abiValidation` extension no longer registered by default so our plugin fails with Kotlin 2.4.0. 

This change is intermediate before switching to new DSL.