### PR TITLE
 Conditionally opt in for experimental features depending on Kotlin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Change Log
 
 ## 0.37.1 *(2026-06-22)*
 - Verify `abiValidation` extension is registered before configuring it.
+- Opt-in for experimental language features now checks for Kotlin language version.
 
 ## 0.37.0 *(2026-05-18)*
 - Remove the iOSX64 target completely. It was already disabled by default since 0.36.7 and is now removed to support new AndroidX versions that have dropped iosX64 support.

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -89,11 +89,13 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                 }
 
                 if (version >= KotlinVersion.KOTLIN_2_2 && version < KotlinVersion.KOTLIN_2_4) {
-                    // Enable 2.2.0 feature previews
                     freeCompilerArgs.addAll(
+                        // Enable 2.2.0 feature previews
                         "-Xcontext-parameters",
                         "-Xcontext-sensitive-resolution",
                         "-Xannotation-target-all",
+                        // https://youtrack.jetbrains.com/issue/KT-73255 - fixed in 2.4
+                        "-Xannotation-default-target=param-property",
                     )
                 }
                 if (version >= KotlinVersion.KOTLIN_2_0) {
@@ -105,8 +107,6 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                 }
 
                 freeCompilerArgs.addAll(
-                    // https://youtrack.jetbrains.com/issue/KT-73255
-                    "-Xannotation-default-target=param-property",
                     // opt in to experimental stdlib apis
                     "-opt-in=kotlin.ExperimentalStdlibApi",
                     "-opt-in=kotlin.time.ExperimentalTime",

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -88,15 +88,25 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                     freeCompilerArgs.add("-Xwarning-level=OVERRIDE_DEPRECATION:disabled")
                 }
 
+                if (version >= KotlinVersion.KOTLIN_2_2 && version < KotlinVersion.KOTLIN_2_4) {
+                    // Enable 2.2.0 feature previews
+                    freeCompilerArgs.addAll(
+                        "-Xcontext-parameters",
+                        "-Xcontext-sensitive-resolution",
+                        "-Xannotation-target-all",
+                    )
+                }
+                if (version >= KotlinVersion.KOTLIN_2_0) {
+                    // Enable 2.0.20 experimental features
+                    freeCompilerArgs.addAll(
+                        // https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor
+                        "-Xconsistent-data-class-copy-visibility",
+                    )
+                }
+
                 freeCompilerArgs.addAll(
                     // https://youtrack.jetbrains.com/issue/KT-73255
                     "-Xannotation-default-target=param-property",
-                    // https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor
-                    "-Xconsistent-data-class-copy-visibility",
-                    // Enable 2.2.0 feature previews
-                    "-Xcontext-parameters",
-                    "-Xcontext-sensitive-resolution",
-                    "-Xannotation-target-all",
                     // opt in to experimental stdlib apis
                     "-opt-in=kotlin.ExperimentalStdlibApi",
                     "-opt-in=kotlin.time.ExperimentalTime",


### PR DESCRIPTION
This ensures plugin stability when experimental features are promoted or dropped in future version, they don't apply automatically and plugin still compiles with newer version (like with 2.4.0 now).