### PR TITLE
Disable compiler flags with optional opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+## 0.38.2 *(2026-06-24)*
+- Disable Kotlin Compiler experimental features by default. Add optional opt-in
+  via gradle properties - `fpg.kotlin.compiler.optInFeaturePreviews.<version>`. Versions supported:
+  - `2_0` - enables `-Xconsistent-data-class-copy-visibility`.
+  - `2_2` - enables `-Xcontext-parameters`, `-Xcontext-sensitive-resolution`, `-Xannotation-target-all`, `-Xannotation-default-target=param-property`.
+  - `2_4` - enables `-Xcollection-literals`, `-Xallow-returns-result-of`, `-Xintrinsic-const-evaluation`.
+
 ## 0.38.1 *(2026-06-24)*
 - Updated SKIE plugin with Kotlin 2.4.0 support.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 java-target = "21"
 java-toolchain = "24"
 
-fgp = "0.38.0"
+fgp = "0.37.2"
 
 kotlin = "2.4.0"
 coroutines = "1.11.0"

--- a/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
+++ b/plugins/src/main/kotlin/com/freeletics/gradle/plugin/FreeleticsBasePlugin.kt
@@ -88,7 +88,12 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                     freeCompilerArgs.add("-Xwarning-level=OVERRIDE_DEPRECATION:disabled")
                 }
 
-                if (version >= KotlinVersion.KOTLIN_2_4) {
+                if (version >= KotlinVersion.KOTLIN_2_4 &&
+                    booleanProperty(
+                        "fgp.kotlin.compiler.optInFeaturePreviews.2_4",
+                        false,
+                    ).get()
+                ) {
                     // Enable 2.4.0 feature previews
                     freeCompilerArgs.addAll(
                         // Bracket syntax for collections initialization
@@ -102,7 +107,12 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                         "-Xintrinsic-const-evaluation",
                     )
                 }
-                if (version >= KotlinVersion.KOTLIN_2_2 && version < KotlinVersion.KOTLIN_2_4) {
+                if (version >= KotlinVersion.KOTLIN_2_2 && version < KotlinVersion.KOTLIN_2_4 &&
+                    booleanProperty(
+                        "fgp.kotlin.compiler.optInFeaturePreviews.2_2",
+                        false,
+                    ).get()
+                ) {
                     freeCompilerArgs.addAll(
                         // Enable 2.2.0 feature previews
                         "-Xcontext-parameters",
@@ -112,7 +122,12 @@ public abstract class FreeleticsBasePlugin : Plugin<Project> {
                         "-Xannotation-default-target=param-property",
                     )
                 }
-                if (version >= KotlinVersion.KOTLIN_2_0) {
+                if (version >= KotlinVersion.KOTLIN_2_0 &&
+                    booleanProperty(
+                        "fgp.kotlin.compiler.optInFeaturePreviews.2_0",
+                        false,
+                    ).get()
+                ) {
                     // Enable 2.0.20 experimental features
                     freeCompilerArgs.addAll(
                         // https://kotlinlang.org/docs/whatsnew2020.html#data-class-copy-function-to-have-the-same-visibility-as-constructor

--- a/scripts/ktlint.main.kts
+++ b/scripts/ktlint.main.kts
@@ -1,6 +1,6 @@
 #!/usr/bin/env kotlin
 
-@file:DependsOn("com.freeletics.gradle:scripts-formatting-jvm:0.38.0")
+@file:DependsOn("com.freeletics.gradle:scripts-formatting-jvm:0.37.2")
 
 import com.freeletics.gradle.scripts.KtLintCli
 import com.github.ajalt.clikt.core.main

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,7 @@ pluginManagement {
 }
 
 plugins {
-    id("com.freeletics.gradle.settings").version("0.38.0")
+    id("com.freeletics.gradle.settings").version("0.37.2")
 }
 
 rootProject.name = "freeletics-gradle-plugins-monorepo"


### PR DESCRIPTION
Revert FGP used to build next release so that it is built with new compiler flags disables. Otherwise it currently breaks downstream binaries.